### PR TITLE
Reconcile the dashboard library aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,18 @@ The Grafana Operator provides a data visualization solution using [Grafana](http
 observability toolkit.
 
 Grafana allows you to query, visualize, alert on, and visualize metrics from mixed datasources in configurable
-dashboards for observability. This repository contains a [Juju](https://jaas.ai/) Charm for deploying the visualization
-component of Grafana in a Kubernetes cluster. 
+dashboards for observability. This repository contains a [Juju](https://jaas.ai/) Charm for deploying the visualization component of Grafana in a Kubernetes cluster. 
 
-The grafana-k8s charm provides an interface which can ingest data from a wide array of data sources, with Prometheus
-as a common input, then presents that data on configurable dashboards.
+The grafana-k8s charm provides an interface which can ingest data from a wide array of data sources, with Prometheus as a common input, then presents that data on configurable dashboards. It is the primary user-facing entrypoint for the Canonical Observability Stack Lite. See the [COS Lite Bundle](https://charmhub.io/cos-lite) for more information.
 
 ## Usage
 
-The Grafana Operator may be deployed using the Juju command line via:
+The Grafana Operator may be deployed on a Kubernetes Juju model using the command line via:
 ```bash
 juju deploy grafana-k8s
 ```
 
-By default, Grafana does not contain any data sources or dashboards, but [Prometheus](https://charmhub.io/prometheus-k8s)
-is commonly used, and is deployable with Juju. The Grafana Operator may also accept additional datasources over Juju
-relations with charms which support the `grafana-datasource` interface.
+At install time, Grafana does not contain any data sources or dashboards, but [Prometheus](https://charmhub.io/prometheus-k8s) is commonly used, and is deployable with Juju. The Grafana Operator may also accept additional datasources over Juju relations with charms which support the `grafana-datasource` interface, such as [Loki](https://charmhub.io/loki-k8s) log visualization.
 
 For example:
 ```bash
@@ -29,13 +25,7 @@ juju deploy prometheus-k8s
 juju relate prometheus-k8s grafana-k8s
 ```
 
-The Grafana Operator includes a Charm library which may be used by other Charms to easily provide datasources with a
-`add_source` method.
-
-View the dashboard in a browser:
-1. `juju status` to check the IP of the of the running Grafana application
-2. Navigate to `http://IP_ADDRESS:3000`
-3. Log in with the default credentials username=admin, password=admin (these credentials are configurable at deploy time)
+The Grafana Operator includes a Charm library which may be used by other Charms to easily provide datasources. Currently, Prometheus and Loki are tested, with datasource integration built into those charms, but any Grafana datasource which does not require the addition of a plugin should be supported. See the documentation for the `charms.grafana_k8s.v0.grafana_source` to learn more.
 
 ## Web Interface
 
@@ -45,9 +35,24 @@ This unit and its IP address can be retrieved using the `juju status` command.
 The default password is randomized at first install, and can be retrieved with:
 ```bash
 juju run-action grafana-k8s/0 get-admin-password --wait
+View the dashboard in a browser:
+1. `juju status` to check the IP of the of the running Grafana application
+2. Navigate to `http://IP_ADDRESS:3000`
+3. Log in with the default credentials username=admin, password=admin (these credentials are configurable at deploy time)
+
 ```
 
 Additionally, Grafana can be accessed via the Kubernetes service matching the Juju application name in the namespace matching the Juju model's name.
+
+## Integration with other charms/adding external dashboards
+
+The grafana-k8s charm does not support directly relating to Reactive charms over the `dashboards` interface, and it does not support adding dashboards via an action similar to the [Reactive Grafana Charm](https://charmhub.io/grafana) as a design goal. For scenarios where Reactive charms which provide dashboards should be integrated, the [COS Proxy](https://charmhub.io/cos-proxy) charm can be deployed in a Reactive model, and related to grafana-k8s to provide a migration path.
+
+Dashboards which are not bundled as part of a charm can be added to grafana-k8s with the [COS Config Charm](https://charmhub.io/cos-configuration-k8s), which can keep a git repository holding your infrastructure-as-code configuration. See the `COS Config` documentation for more information.
+
+## To Bundle Dashboards As Part of Your Charm
+
+See the documentation for the `charm.grafana_k8s.v0.grafana_dashboard` library. Generally, this only requires adding a `grafana-dashboard` interface to your charm and putting the dashboard templates into a configurable path.
 
 ## High Availability Grafana
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -499,7 +499,6 @@ class GrafanaDashboardProvider(Object):
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
         )
 
-        dashboards_path = ""
         try:
             dashboards_path = _resolve_dir_against_charm_path(charm, dashboards_path)
         except InvalidDirectoryPathError as e:

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1,7 +1,166 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""A library for integrating Grafana dashboards in charmed operators."""
+"""## Overview.
+
+This document explains how to integrate with the Grafana charm
+for the purpose of providing a dashboard which can be used by
+end users. It also explains the structure of the data
+expected by the `grafana-dashboard` interface, and may provide a
+mechanism or reference point for providing a compatible interface
+or library by providing a definitive reference guide to the
+structure of relation data which is shared between the Grafana
+charm and any charm providing datasource information.
+
+## Provider Library Usage
+
+The Grafana charm interacts with its dashboards using its charm
+library. The goal of this library is to be as simple to use as
+possible, and instantiation of the class with or without changing
+the default arguments provides a complete use case. For the simplest
+use case of a charm which bundles dashboards and provides a
+`provides: grafana-dashboard` interface, creation of a
+`GrafanaDashboardProvider` object with the default arguments is
+sufficient.
+
+:class:`GrafanaDashboardProvider` expects that bundled dashboards should
+be included in your charm with a default path of:
+
+    path/to/charm.py
+    path/to/src/grafana_dashboards/*.tmpl
+
+Where the `*.tmpl` files are Grafana dashboard JSON data either from the
+Grafana marketplace, or directly exported from a a Grafana instance.
+
+The default arguments are:
+
+    `charm`: `self` from the charm instantiating this library
+    `relation_name`: grafana-dashboard
+    `dashboards_path`: "/src/grafana_dashboards"
+
+If your configuration requires any changes from these defaults, they
+may be set from the class constructor. It may be instantiated as
+follows:
+
+    from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
+
+    class FooCharm:
+        def __init__(self, *args):
+            super().__init__(*args, **kwargs)
+            ...
+            self.grafana_dashboard_provider = GrafanaDashboardProvider(self)
+            ...
+
+The first argument (`self`) should be a reference to the parent (providing
+dashboards), as this charm's lifecycle events will be used to re-submit
+dashboard information if a charm is upgraded, the pod is restarted, or other.
+
+An instantiated `GrafanaDashboardProvider` validates that the path specified
+in the constructor (or the default) exists, reads the file contents, then
+compresses them with LZMA and adds them to the application relation data
+when a relation is established with Grafana.
+
+Provided dashboards will be checked by Grafana, and a series of dropdown menus
+providing the ability to select query targets by Juju Model, application instance,
+and unit will be added if they do not exist.
+
+To avoid requiring `jinja` in `GrafanaDashboardProvider` users, templte validation
+and rendering occurs on the other side of the relation, and relation data in
+the form of:
+
+    {
+        "event": {
+            "valid": `true|false`,
+            "errors": [],
+        }
+    }
+
+Will be returned if rendering or validation fails. In this case, the
+`GrafanaDashboardProvider` object will emit a `dashboard_status_changed` event
+of the type :class:`GrafanaDashboardEvent`, which will contain information
+about the validation error.
+
+This information is added to the relation data for the charms as serialized JSON
+from a dict, with a structure of:
+```
+{
+    "application": {
+        "dashboards": {
+            "uuid": a uuid generated to ensure a relation event triggers,
+            "templates": {
+                "file:{hash}": {
+                    "content": `{compressed_template_data}`,
+                    "charm": `charm.meta.name`,
+                    "juju_topology": {
+                        "model": `charm.model.name`,
+                        "model_uuid": `charm.model.uuid`,
+                        "application": `charm.app.name`,
+                        "unit": `charm.unit.name`,
+                    }
+                },
+                "file:{other_file_hash}": {
+                    ...
+                },
+            },
+        },
+    },
+}
+```
+
+This is ingested by :class:`GrafanaDashboardConsumer`, and is sufficient for configuration.
+
+The [COS Configuration Charm](https://charmhub.io/cos-configuration-k8s) can be used to
+add dashboards which are bundled with charms.
+
+## Consumer Library Usage
+
+The `GrafanaDashboardConsumer` object may be used by Grafana
+charms to manage relations with available dashboards. For this
+purpose, a charm consuming Grafana dashboard information should do
+the following things:
+
+1. Instantiate the `GrafanaDashboardConsumer` object by providing it a
+reference to the parent (Grafana) charm and, optionally, the name of
+the relation that the Grafana charm uses to interact with dashboards.
+This relation must confirm to the `grafana-dashboard` interface.
+
+For example a Grafana charm may instantiate the
+`GrafanaDashboardConsumer` in its constructor as follows
+
+    from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardConsumer
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        ...
+        self.grafana_dashboard_consumer = GrafanaDashboardConsumer(self)
+        ...
+
+2. A Grafana charm also needs to listen to the
+`GrafanaDashboardConsumer` events emitted by the `GrafanaDashboardConsumer`
+by adding itself as an observer for these events:
+
+    self.framework.observe(
+        self.grafana_source_consumer.on.sources_changed,
+        self._on_dashboards_changed,
+    )
+
+Dashboards can be retrieved the :meth:`dashboards`:
+
+It will be returned in the format of:
+
+```
+[
+    {
+        "id": unique_id,
+        "relation_id": relation_id,
+        "charm": the name of the charm which provided the dashboard,
+        "content": compressed_template_data
+    },
+]
+```
+
+The consuming charm should decompress the dashboard.
+"""
 
 import base64
 import json
@@ -41,7 +200,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -64,7 +64,7 @@ Provided dashboards will be checked by Grafana, and a series of dropdown menus
 providing the ability to select query targets by Juju Model, application instance,
 and unit will be added if they do not exist.
 
-To avoid requiring `jinja` in `GrafanaDashboardProvider` users, templte validation
+To avoid requiring `jinja` in `GrafanaDashboardProvider` users, template validation
 and rendering occurs on the other side of the relation, and relation data in
 the form of:
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -311,7 +311,7 @@ class GrafanaSourceProvider(Object):
         self,
         charm: CharmBase,
         refresh_event: Optional[BoundEvent] = None,
-        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
+        relation_name: str = DEFAULT_RELATION_NAME,
         source_type: Optional[str] = "prometheus",
         source_port: Optional[str] = "9090",
     ) -> None:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -6,7 +6,7 @@
 This document explains how to integrate with the Grafana charm
 for the purpose of providing a datasource which can be used by
 Grafana dashboards. It also explains the structure of the data
-expected by the `grafana-dashboard` interface, and may provide a
+expected by the `grafana-source` interface, and may provide a
 mechanism or reference point for providing a compatible interface
 or library by providing a definitive reference guide to the
 structure of relation data which is shared between the Grafana

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -1,7 +1,122 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""A library for working with Grafana datasources for charm authors."""
+"""## Overview.
+
+This document explains how to integrate with the Grafana charm
+for the purpose of providing a datasource which can be used by
+Grafana dashboards. It also explains the structure of the data
+expected by the `grafana-dashboard` interface, and may provide a
+mechanism or reference point for providing a compatible interface
+or library by providing a definitive reference guide to the
+structure of relation data which is shared between the Grafana
+charm and any charm providing datasource information.
+
+## Provider Library Usage
+
+The Grafana charm interacts with its datasources using its charm
+library. The goal of this library is to be as simple to use as
+possible, and instantiation of the class with or without changing
+the default arguments provides a complete use case. For the simplest
+use case of a Prometheus (or Prometheus-compatible) datasource
+provider in a charm which `provides: grafana-source`, creation of a
+`GrafanaSourceProvider` object with the default arguments is sufficient.
+
+The default arguments are:
+
+    `charm`: `self` from the charm instantiating this library
+    `relation_name`: grafana-source
+    `refresh_event`: A `PebbleReady` event from `charm`, used to refresh
+        the IP address sent to Grafana on a charm lifecycle event or
+        pod restart
+    `source_type`: prometheus
+    `source_port`: 9090
+
+If your configuration requires any changes from these defaults, they
+may be set from the class constructor. It may be instantiated as
+follows:
+
+    from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
+
+    class FooCharm:
+        def __init__(self, *args):
+            super().__init__(*args, **kwargs)
+            ...
+            self.grafana_source_provider = GrafanaSourceProvider(self)
+            ...
+
+The first argument (`self`) should be a reference to the parent (datasource)
+charm, as this charm's model will be used for relation data, IP addresses,
+and lifecycle events.
+
+An instantiated `GrafanaSourceProvider` will ensure that each unit of its
+parent charm is added as a datasource in the Grafana configuration once a
+relation is established, using the [Grafana datasource provisioning](
+https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources)
+specification via YAML files.
+
+This information is added to the relation data for the charms as serialized JSON
+from a dict, with a structure of:
+```
+{
+    "application": {
+        "model": charm.model.name, # from `charm` in the constructor
+        "model_uuid": charm.model.uuid,
+        "application": charm.model.app.name,
+        "type": source_type,
+    },
+    "unit/0": {
+        "uri": {ip_address}:{port} # `ip_address` is derived at runtime, `port` from the constructor
+    },
+```
+
+This is ingested by :class:`GrafanaSourceConsumer`, and is sufficient for configuration.
+
+
+## Consumer Library Usage
+
+The `GrafanaSourceConsumer` object may be used by Grafana
+charms to manage relations with available datasources. For this
+purpose, a charm consuming Grafana datasource information should do
+the following things:
+
+1. Instantiate the `GrafanaSourceConsumer` object by providing it a
+reference to the parent (Grafana) charm and, optionally, the name of
+the relation that the Grafana charm uses to interact with datasources.
+This relation must confirm to the `grafana-source` interface.
+
+For example a Grafana charm may instantiate the
+`GrafanaSourceConsumer` in its constructor as follows
+
+    from charms.grafana_k8s.v0.grafana_source import GrafanaSourceConsumer
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        ...
+        self.grafana_source_consumer = GrafanaSourceConsumer(self)
+        ...
+
+2. A Grafana charm also needs to listen to the
+`GrafanaSourceEvents` events emitted by the `GrafanaSourceConsumer`
+by adding itself as an observer for these events:
+
+    self.framework.observe(
+        self.grafana_source_consumer.on.sources_changed,
+        self._on_sources_changed,
+    )
+    self.framework.observe(
+        self.grafana_source_consumer.on.sources_to_delete_changed,
+        self._on_sources_to_delete_change,
+    )
+
+The reason for two separate events is that Grafana keeps track of
+removed datasources in its [datasource provisioning](
+https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources).
+
+If your charm is merely implementing a `grafana-source`-compatible API,
+and is does not follow exactly the same semantics as Grafana, observing these
+events may not be needed.
+"""
 
 import json
 import logging
@@ -35,7 +150,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 logger = logging.getLogger(__name__)
 
@@ -195,8 +310,8 @@ class GrafanaSourceProvider(Object):
     def __init__(
         self,
         charm: CharmBase,
-        refresh_event: BoundEvent,
-        relation_name: str = DEFAULT_RELATION_NAME,
+        refresh_event: Optional[BoundEvent] = None,
+        relation_name: Optional[str] = DEFAULT_RELATION_NAME,
         source_type: Optional[str] = "prometheus",
         source_port: Optional[str] = "9090",
     ) -> None:
@@ -242,6 +357,8 @@ class GrafanaSourceProvider(Object):
         self._charm = charm
         self._relation_name = relation_name
         events = self._charm.on[relation_name]
+
+        refresh_event = refresh_event or self._charm.on.pebble_ready
 
         self._source_type = source_type
         self._source_port = source_port

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107", "E203"]
+ignore = ["W503", "W505", "E501", "D107", "E203"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103"]
 docstring-convention = "google"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -136,7 +136,6 @@ async def get_grafana_dashboards(ops_test: OpsTest, app_name: str, unit_num: int
 
     Args:
         app_name: string name of Grafana application
-        query_string: the search string to use
 
     Returns:
         a list of dashboards


### PR DESCRIPTION
Bring it in sync with changes from the proxy.

Make it more resilient to charm lifecycle events, basically.