### PR TITLE
Do a lot more work on dashboard templates

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -200,7 +200,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 logger = logging.getLogger(__name__)
 
@@ -517,17 +517,75 @@ def _decode_dashboard_content(encoded_content: str) -> str:
     return lzma.decompress(base64.b64decode(encoded_content.encode("utf-8"))).decode()
 
 
-def _inject_dashboard_dropdowns(content: str) -> str:
-    """Make sure dropdowns are present for Juju topology."""
+def _convert_dashboard_fields(content: str) -> str:
+    """Make sure values are present for Juju topology.
+
+    Inserts Juju topology variables and selectors into the template, as well as
+    a variable for Prometheus.
+    """
     dict_content = json.loads(content)
+    datasources = {}
+    existing_templates = False
     if "templating" not in content:
         dict_content["templating"] = {"list": [d for d in TEMPLATE_DROPDOWNS]}
     else:
+        existing_templates = True
+        for maybe in dict_content["templating"]["list"]:
+            if "type" in maybe and maybe["type"] == "datasource":
+                datasources[maybe["name"]] = maybe["query"]
+
+        # Put our own variables in the template
         for d in TEMPLATE_DROPDOWNS:
             if d not in dict_content["templating"]["list"]:
                 dict_content["templating"]["list"].insert(0, d)
 
+    dict_content = _replace_template_fields(dict_content, datasources, existing_templates)
+
     return json.dumps(dict_content)
+
+
+def _replace_template_fields(
+    dict_content: dict, datasources: dict, existing_templates: bool
+) -> dict:
+    """Make templated fields get cleaned up afterwards.
+
+    If existing datasource variables are present, try to substitute them, otherwise
+    assume they are all for Prometheus and put the prometheus variable there.
+    """
+    replacements = {"loki": "${lokids}", "prometheus": "${prometheusds}"}
+    used_replacements = []
+
+    # If any existing datasources match types we know, or we didn't find
+    # any templating variables at all, template them.
+    if datasources or not existing_templates:
+        panels = dict_content["panels"]
+
+        for panel in panels:
+            if "datasource" not in panel:
+                continue
+            if not existing_templates:
+                panel["datasource"] = "${prometheusds}"
+            else:
+                # Strip out variable characters and maybe braces
+                ds = re.sub(r"(\$|\{|\})", "", panel["datasource"])
+                replacement = replacements.get(datasources[ds], "")
+                if replacement:
+                    used_replacements.append(ds)
+                panel["datasource"] = replacement or panel["datasource"]
+
+        # Put our substitutions back
+        dict_content["panels"] = panels
+
+    # Finally, go back and pop off the templates we stubbed out
+    deletions = []
+    for tmpl in dict_content["templating"]["list"]:
+        if tmpl["name"] and tmpl["name"] in used_replacements:
+            deletions.append(tmpl)
+
+    for d in deletions:
+        dict_content["templating"]["list"].remove(d)
+
+    return dict_content
 
 
 def _type_convert_stored(obj):
@@ -1017,7 +1075,10 @@ class GrafanaDashboardConsumer(Object):
             error = None
             try:
                 content = Template(decoded_content).render()
-                content = _encode_dashboard_content(_inject_dashboard_dropdowns(content))
+                content = _encode_dashboard_content(_convert_dashboard_fields(content))
+            except json.JSONDecodeError as e:
+                error = str(e.msg)
+                relation_has_invalid_dashboards = True
             except TemplateSyntaxError as e:
                 error = str(e)
                 relation_has_invalid_dashboards = True

--- a/src/charm.py
+++ b/src/charm.py
@@ -169,6 +169,9 @@ class GrafanaCharm(CharmBase):
         already stored in the charm. If either the base Grafana config
         or the datasource config differs, restart Grafana.
         """
+        if not self.container.can_connect():
+            return
+
         logger.debug("Handling grafana-k8a configuration change")
         restart = False
 
@@ -193,10 +196,7 @@ class GrafanaCharm(CharmBase):
 
             restart = True
 
-        if (
-            self.container.can_connect()
-            and self.container.get_plan().services != self._build_layer().services
-        ):
+        if self.container.get_plan().services != self._build_layer().services:
             restart = True
 
         if restart:

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -54,6 +54,78 @@ SOURCE_DATA = {
     "uuid": "12345678",
 }
 
+VARIABLE_DASHBOARD_TEMPLATE = """
+{
+    "panels": [
+        {
+            "data": "label_values(up, juju_unit)",
+            "datasource": "$replace_me"
+        }
+    ]
+}
+"""
+
+VARIABLE_DASHBOARD_RENDERED = json.dumps(
+    {
+        "panels": [
+            {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
+        ],
+        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+    }
+)
+
+EXISTING_VARIABLE_DASHBOARD_TEMPLATE = """
+{
+    "panels": [
+        {
+            "data": "label_values(up, juju_unit)",
+            "datasource": "${replace_me_too}"
+        },
+        {
+            "data": "label_values(up, juju_application)",
+            "datasource": "$replace_me_also"
+        },
+        {
+            "data": "label_values(up, juju_unit)",
+            "datasource": "${leave_me_alone}"
+        }
+    ],
+    "templating": {
+        "list": [
+            {
+                "name": "replace_me_too",
+                "query": "prometheus",
+                "type": "datasource"
+            },
+            {
+                "name": "replace_me_also",
+                "query": "prometheus",
+                "type": "datasource"
+            },
+            {
+                "name": "leave_me_alone",
+                "query": "influxdb",
+                "type": "datasource"
+            }
+        ]
+    }
+}
+"""
+
+EXISTING_VARIABLE_DASHBOARD_RENDERED = json.dumps(
+    {
+        "panels": [
+            {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
+            {"data": "label_values(up, juju_application)", "datasource": "${prometheusds}"},
+            {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
+        ],
+        "templating": {
+            "list": [d for d in reversed(TEMPLATE_DROPDOWNS)]
+            + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
+        },
+    }
+)
+
 
 class ConsumerCharm(CharmBase):
     _stored = StoredState()
@@ -87,13 +159,8 @@ class TestDashboardConsumer(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.begin()
 
-    def setup_charm_relations(self):
-        """Create relations used by test cases.
-
-        Args:
-            multi: a boolean indicating if multiple relations must be
-            created.
-        """
+    def setup_charm_relations(self) -> list:
+        """Create relations used by test cases."""
         rel_ids = []
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
         source_rel_id = self.harness.add_relation("grafana-source", "source")
@@ -106,6 +173,34 @@ class TestDashboardConsumer(unittest.TestCase):
             "provider",
             {
                 "dashboards": json.dumps(SOURCE_DATA),
+            },
+        )
+
+        return rel_ids
+
+    def setup_different_dashboard(self, template: str) -> list:
+        """Create relations used by test cases with alternate templates."""
+        rel_ids = []
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        source_rel_id = self.harness.add_relation("grafana-source", "source")
+        self.harness.add_relation_unit(source_rel_id, "source/0")
+        rel_id = self.harness.add_relation("grafana-dashboard", "provider")
+        self.harness.add_relation_unit(rel_id, "provider/0")
+        rel_ids.append(rel_id)
+
+        d = DASHBOARD_DATA
+        d["content"] = template
+
+        data = {
+            "templates": {"file:tester": d},
+            "uuid": "12345678",
+        }
+
+        self.harness.update_relation_data(
+            rel_id,
+            "provider",
+            {
+                "dashboards": json.dumps(data),
             },
         )
 
@@ -168,6 +263,85 @@ class TestDashboardConsumer(unittest.TestCase):
                 {
                     "dashboard_id": "file:tester",
                     "error": "expected token 'end of print statement', got 'variable'",
+                }
+            ],
+        )
+
+    def test_consumer_error_on_bad_json(self):
+        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        rels = self.setup_charm_relations()
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
+
+        bad_data = {
+            "templates": {
+                "file:tester": {
+                    "charm": "grafana-k8s",
+                    "content": '{ "foo": "bar",,},',
+                    "juju_topology": {
+                        "model": MODEL_INFO["name"],
+                        "model_uuid": MODEL_INFO["uuid"],
+                        "application": "provider-tester",
+                        "unit": "provider-tester/0",
+                    },
+                }
+            },
+            "uuid": "12345678",
+        }
+
+        self.harness.update_relation_data(
+            rels[0],
+            "provider",
+            {
+                "dashboards": json.dumps(bad_data),
+            },
+        )
+
+        data = json.loads(
+            self.harness.get_relation_data(rels[0], self.harness.model.app.name)["event"]
+        )
+        self.assertEqual(
+            data["errors"],
+            [
+                {
+                    "dashboard_id": "file:tester",
+                    "error": "Expecting property name enclosed in double quotes",
+                }
+            ],
+        )
+
+    def test_consumer_templates_datasource(self):
+        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        self.setup_different_dashboard(VARIABLE_DASHBOARD_TEMPLATE)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
+
+        self.assertEqual(
+            self.harness.charm.grafana_consumer.dashboards,
+            [
+                {
+                    "id": "file:tester",
+                    "relation_id": 1,
+                    "charm": "grafana-k8s",
+                    "content": VARIABLE_DASHBOARD_RENDERED,
+                }
+            ],
+        )
+
+    def test_consumer_templates_dashboard_and_keeps_variables(self):
+        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        self.setup_different_dashboard(EXISTING_VARIABLE_DASHBOARD_TEMPLATE)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
+
+        self.assertEqual(
+            self.harness.charm.grafana_consumer.dashboards,
+            [
+                {
+                    "id": "file:tester",
+                    "relation_id": 1,
+                    "charm": "grafana-k8s",
+                    "content": EXISTING_VARIABLE_DASHBOARD_RENDERED,
                 }
             ],
         )


### PR DESCRIPTION
Return an appropriate error to the Provider if the JSON is bad.

If there are no template variables, assume any datasources are
prometheus (impossible to tell from `panel` objects), and replace
their values with `${prometheusds}`

If there **are** template variables, sift through them. If they
are known types for Loki or Prometheus, replace them by name in the
templates, then go back and clean them up from template variables.

Add tests for all of this, obviously.

Closes #60 