### PR TITLE
Move away from StoredState for Grafana.*Consumer and charm app/unit data

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1055,7 +1055,7 @@ class GrafanaDashboardConsumer(Object):
             )
 
             for relation in relations:
-                self._render_dashboards_and_signal_changed(relation)
+                self._render_dashboards_and_signal_changed(relation)  # type: ignore
 
         if changes:
             self.on.dashboards_changed.emit()

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1090,7 +1090,7 @@ class GrafanaDashboardConsumer(Object):
             self.on.dashboards_changed.emit()
         else:
             stored_data = rendered_dashboards
-            currently_stored_data = self._get_stored_dashboards(relation.id) or {}  # type: ignore
+            currently_stored_data = self._get_stored_dashboards(relation.id)  # type: ignore
 
             coerced_data = (
                 _type_convert_stored(currently_stored_data) if currently_stored_data else {}
@@ -1099,7 +1099,7 @@ class GrafanaDashboardConsumer(Object):
             if not coerced_data == stored_data:
                 stored_dashboards = self.get_peer_data("dashboards")
                 stored_dashboards[relation.id] = stored_data
-                self.set_peer_data({"dashboards": stored_dashboards})
+                self.set_peer_data("dashboards", stored_dashboards)
                 self.on.dashboards_changed.emit()
 
     def _remove_all_dashboards_for_relation(self, relation: Relation) -> None:
@@ -1107,7 +1107,7 @@ class GrafanaDashboardConsumer(Object):
         if self._get_stored_dashboards(relation.id):
             stored_dashboards = self.get_peer_data("dashboards")
             stored_dashboards.pop(relation.id)
-            self.set_peer_data({"dashboards": stored_dashboards})
+            self.set_peer_data("dashboards", stored_dashboards)
             self.on.dashboards_changed.emit()
 
     def _to_external_object(self, relation_id, dashboard):
@@ -1144,12 +1144,11 @@ class GrafanaDashboardConsumer(Object):
         data = {"dashboards": {}}  # type: ignore
         for k, v in data.items():
             if not self.get_peer_data(k):
-                self.set_peer_data({k: v})
+                self.set_peer_data(k, v)
 
-    def set_peer_data(self, data: dict) -> None:
+    def set_peer_data(self, key: str, data: Any) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
-        for k, v in data.items():
-            self._charm.peers.data[self._charm.app][k] = json.dumps(v)  # type: ignore
+        self._charm.peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
         """Put information into the peer data bucket instead of `StoredState`."""

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1071,7 +1071,7 @@ class GrafanaDashboardConsumer(Object):
 
         self._remove_all_dashboards_for_relation(event.relation)
 
-    def _render_dashboards_and_signal_changed(self, relation: Relation) -> bool:
+    def _render_dashboards_and_signal_changed(self, relation: Relation) -> bool:  # type: ignore
         """Validate a given dashboard.
 
         Verify that the passed dashboard data is able to be found in our list

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1240,7 +1240,7 @@ class GrafanaDashboardConsumer(Object):
         self._charm.peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
-        """Put information into the peer data bucket instead of `StoredState`."""
+        """Retrieve information from the peer data bucket instead of `StoredState`."""
         data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore
         return json.loads(data) if data else {}
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1090,7 +1090,7 @@ class GrafanaDashboardConsumer(Object):
             self.on.dashboards_changed.emit()
         else:
             stored_data = rendered_dashboards
-            currently_stored_data = self._get_stored_dashboards(relation.id)  # type: ignore
+            currently_stored_data = self._get_stored_dashboards(relation.id)
 
             coerced_data = (
                 _type_convert_stored(currently_stored_data) if currently_stored_data else {}

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1090,7 +1090,7 @@ class GrafanaDashboardConsumer(Object):
             self.on.dashboards_changed.emit()
         else:
             stored_data = rendered_dashboards
-            currently_stored_data = self._get_stored_dashboards(relation.id) or {}
+            currently_stored_data = self._get_stored_dashboards(relation.id) or {}  # type: ignore
 
             coerced_data = (
                 _type_convert_stored(currently_stored_data) if currently_stored_data else {}
@@ -1141,7 +1141,7 @@ class GrafanaDashboardConsumer(Object):
 
     def _set_default_data(self) -> None:
         """Set defaults if they are not in peer relation data."""
-        data = {"dashboards": {}}
+        data = {"dashboards": {}}  # type: ignore
         for k, v in data.items():
             if not self.get_peer_data(k):
                 self.set_peer_data({k: v})
@@ -1149,11 +1149,11 @@ class GrafanaDashboardConsumer(Object):
     def set_peer_data(self, data: dict) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
         for k, v in data.items():
-            self._charm.peers.data[self._charm.app][k] = json.dumps(v)
+            self._charm.peers.data[self._charm.app][k] = json.dumps(v)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
         """Put information into the peer data bucket instead of `StoredState`."""
-        data = self._charm.peers.data[self._charm.app].get(key, "")
+        data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore
         return json.loads(data) if data else {}
 
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -472,7 +472,7 @@ class GrafanaSourceConsumer(Object):
             if source:
                 sources[rel.id] = source
 
-        self.set_peer_data({"sources": sources})
+        self.set_peer_data("sources", sources)
 
         self.on.sources_changed.emit()
 
@@ -504,7 +504,7 @@ class GrafanaSourceConsumer(Object):
                 sources_to_delete.remove(host_data["source_name"])
 
             data.append(host_data)
-        self.set_peer_data({"sources_to_delete": list(sources_to_delete)})
+        self.set_peer_data("sources_to_delete", list(sources_to_delete))
         return data
 
     def _relation_hosts(self, rel: Relation) -> Dict:
@@ -564,7 +564,7 @@ class GrafanaSourceConsumer(Object):
                 for host in removed_source:
                     self._remove_source(host["source_name"])
 
-            self.set_peer_data({"sources": stored_sources})
+            self.set_peer_data("sources", stored_sources)
             self.on.sources_to_delete_changed.emit()
 
     def _remove_source(self, source_name: str) -> None:
@@ -572,7 +572,7 @@ class GrafanaSourceConsumer(Object):
         sources_to_delete = self.get_peer_data("sources_to_delete")
         if source_name not in sources_to_delete:
             sources_to_delete.append(source_name)
-            self.set_peer_data({"sources_to_delete": sources_to_delete})
+            self.set_peer_data("sources_to_delete", sources_to_delete)
 
     def upgrade_keys(self) -> None:
         """On upgrade, ensure stored data maintains compatibility."""
@@ -591,14 +591,14 @@ class GrafanaSourceConsumer(Object):
             self._stored.sources = {}
             peer_sources = self.get_peer_data("sources")
             sources = {**sources, **peer_sources}
-            self.set_peer_data({"sources": sources})
+            self.set_peer_data("sources", sources)
 
         if self._stored.sources_to_delete:
             old_sources_to_delete = _type_convert_stored(self._stored.sources_to_delete)
             self._stored.sources_to_delete = set()
             peer_sources_to_delete = set(self.get_peer_data("sources_to_delete"))
             sources_to_delete = set.union(old_sources_to_delete, peer_sources_to_delete)
-            self.set_peer_data({"sources_to_delete": sources_to_delete})
+            self.set_peer_data("sources_to_delete", sources_to_delete)
 
     @property
     def sources(self) -> List[dict]:
@@ -620,12 +620,11 @@ class GrafanaSourceConsumer(Object):
         data = {"sources": {}, "sources_to_delete": []}  # type: ignore
         for k, v in data.items():
             if not self.get_peer_data(k):
-                self.set_peer_data({k: v})
+                self.set_peer_data(k, v)
 
-    def set_peer_data(self, data: dict) -> None:
+    def set_peer_data(self, key: str, data: Any) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
-        for k, v in data.items():
-            self._charm.peers.data[self._charm.app][k] = json.dumps(v)  # type: ignore
+        self._charm.peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
         """Put information into the peer data bucket instead of `StoredState`."""

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -606,7 +606,7 @@ class GrafanaSourceConsumer(Object):
         if self._stored.sources:
             self._stored.sources = {}
             peer_sources = self.get_peer_data("sources")
-            sources = {**sources, **peer_sources}
+            sources.update(peer_sources)
             self.set_peer_data("sources", sources)
 
         if self._stored.sources_to_delete:
@@ -643,6 +643,6 @@ class GrafanaSourceConsumer(Object):
         self._charm.peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
-        """Put information into the peer data bucket instead of `StoredState`."""
+        """Retrieve information from the peer data bucket instead of `StoredState`."""
         data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore
         return json.loads(data) if data else {}

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -617,7 +617,7 @@ class GrafanaSourceConsumer(Object):
 
     def _set_default_data(self) -> None:
         """Set defaults if they are not in peer relation data."""
-        data = {"sources": {}, "sources_to_delete": []}
+        data = {"sources": {}, "sources_to_delete": []}  # type: ignore
         for k, v in data.items():
             if not self.get_peer_data(k):
                 self.set_peer_data({k: v})
@@ -625,9 +625,9 @@ class GrafanaSourceConsumer(Object):
     def set_peer_data(self, data: dict) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
         for k, v in data.items():
-            self._charm.peers.data[self._charm.app][k] = json.dumps(v)
+            self._charm.peers.data[self._charm.app][k] = json.dumps(v)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
         """Put information into the peer data bucket instead of `StoredState`."""
-        data = self._charm.peers.data[self._charm.app].get(key, "")
+        data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore
         return json.loads(data) if data else {}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,7 +34,7 @@ requires:
     interface: db
     limit: 1
 peers:
-  grafana-peers:
+  grafana:
     interface: grafana_peers
 resources:
   grafana-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -244,7 +244,7 @@ class GrafanaCharm(CharmBase):
 
     def set_peer_data(self, key: str, data: Any) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
-        self.peers.data[self.app][key] = json.dumps(data)  # type: ignore
+        self.peers.data[self.app][key] = json.dumps(data)
 
     def get_peer_data(self, key: str) -> Any:
         """Put information into the peer data bucket instead of `StoredState`."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -242,10 +242,9 @@ class GrafanaCharm(CharmBase):
         """Fetch the peer relation."""
         return self.model.get_relation(PEER)
 
-    def set_peer_data(self, data: dict) -> None:
+    def set_peer_data(self, key: str, data: Any) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
-        for k, v in data.items():
-            self.peers.data[self.app][k] = json.dumps(v)
+        self.peers.data[self.app][key] = json.dumps(data)  # type: ignore
 
     def get_peer_data(self, key: str) -> Any:
         """Put information into the peer data bucket instead of `StoredState`."""
@@ -384,7 +383,7 @@ class GrafanaCharm(CharmBase):
 
         # add the new database relation data to the datastore
         db_info = {field: value for field, value in database_fields.items() if value}
-        self.set_peer_data({"database": db_info})
+        self.set_peer_data("database", db_info)
 
         self._configure()
 
@@ -402,7 +401,7 @@ class GrafanaCharm(CharmBase):
             return
 
         # remove the existing database info from datastore
-        self.set_peer_data({"database": {}})
+        self.set_peer_data("database", {})
         logger.info("Removing the grafana-k8s database backend config")
 
         # Cleanup the config file

--- a/src/charm.py
+++ b/src/charm.py
@@ -170,7 +170,7 @@ class GrafanaCharm(CharmBase):
         already stored in the charm. If either the base Grafana config
         or the datasource config differs, restart Grafana.
         """
-        logger.debug("Handling grafana-k8a configuration change")
+        logger.debug("Handling grafana-k8s configuration change")
         restart = False
 
         # Generate a new base config and see if it differs from what we have.

--- a/src/charm.py
+++ b/src/charm.py
@@ -234,7 +234,7 @@ class GrafanaCharm(CharmBase):
     @property
     def has_peers(self) -> bool:
         """Check whether or not there are any other Grafanas as peers."""
-        rel = self.model.get_relation(self.app)
+        rel = self.model.get_relation(PEER)
         return len(rel.units) > 0 if rel is not None else False
 
     @property
@@ -247,7 +247,7 @@ class GrafanaCharm(CharmBase):
         self.peers.data[self.app][key] = json.dumps(data)
 
     def get_peer_data(self, key: str) -> Any:
-        """Put information into the peer data bucket instead of `StoredState`."""
+        """Retrieve information from the peer data bucket instead of `StoredState`."""
         data = self.peers.data[self.app].get(key, "")
         return json.loads(data) if data else {}
 

--- a/tests/integration/test_multiple_units.py
+++ b/tests/integration/test_multiple_units.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import itertools
+import logging
+
+import pytest
+from helpers import (
+    check_grafana_is_ready,
+    get_dashboard_by_search,
+    get_datasource_for,
+    get_grafana_dashboards,
+    get_grafana_datasources,
+    oci_image,
+)
+
+logger = logging.getLogger(__name__)
+
+tester_resources = {
+    "grafana-tester-image": oci_image(
+        "./tests/integration/grafana-tester/metadata.yaml", "grafana-tester-image"
+    )
+}
+grafana_resources = {"grafana-image": oci_image("./metadata.yaml", "grafana-image")}
+
+
+@pytest.mark.abort_on_fail
+async def test_grafana_dashboard_relation_data_with_grafana_tester(
+    ops_test, grafana_charm, grafana_tester_charm
+):
+    """Test basic functionality of grafana-dashboard relation interface."""
+    grafana_app_name = "grafana"
+    tester_app_name = "grafana-tester"
+
+    await asyncio.gather(
+        ops_test.model.deploy(
+            grafana_charm, resources=grafana_resources, application_name=grafana_app_name
+        ),
+        ops_test.model.deploy(
+            grafana_tester_charm, resources=tester_resources, application_name=tester_app_name
+        ),
+    )
+    await asyncio.gather(
+        ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active"),
+        ops_test.model.wait_for_idle(apps=[tester_app_name], status="active"),
+    )
+    await ops_test.model.applications[grafana_app_name].scale(scale=2)
+    await asyncio.gather(
+        ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[grafana_app_name].units) == 2
+        ),
+        ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[tester_app_name].units) > 0
+        ),
+    )
+
+    # Idle again to ensure the second unit has an ddress
+    await ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active")
+
+    assert ops_test.model.applications[grafana_app_name].units[0].workload_status == "active"
+    assert ops_test.model.applications[grafana_app_name].units[1].workload_status == "active"
+    assert ops_test.model.applications[tester_app_name].units[0].workload_status == "active"
+
+    await check_grafana_is_ready(ops_test, grafana_app_name, 0)
+    await check_grafana_is_ready(ops_test, grafana_app_name, 1)
+
+    initial_dashboards = await asyncio.gather(
+        get_grafana_dashboards(ops_test, grafana_app_name, 0),
+        get_grafana_dashboards(ops_test, grafana_app_name, 1),
+    )
+    initial_datasources = await asyncio.gather(
+        get_grafana_datasources(ops_test, grafana_app_name, 0),
+        get_grafana_datasources(ops_test, grafana_app_name, 1),
+    )
+
+    initial_dashboards = list(itertools.chain.from_iterable(initial_dashboards))
+    initial_datasources = list(itertools.chain.from_iterable(initial_datasources))
+
+    assert initial_dashboards == []
+    assert initial_datasources == []
+
+    await asyncio.gather(
+        ops_test.model.add_relation(
+            "{}:grafana-source".format(grafana_app_name),
+            "{}:grafana-source".format(tester_app_name),
+        ),
+        ops_test.model.add_relation(
+            "{}:grafana-dashboard".format(grafana_app_name),
+            "{}:grafana-dashboard".format(tester_app_name),
+        ),
+    )
+    await ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active")
+
+    tester_dashboards = await asyncio.gather(
+        get_dashboard_by_search(ops_test, grafana_app_name, 0, "Grafana Tester"),
+        get_dashboard_by_search(ops_test, grafana_app_name, 1, "Grafana Tester"),
+    )
+    assert tester_dashboards[0] != {}
+
+    # Dashboard provisioning randomizes the UID, as well as datetime fields
+    # based on processing time
+    update_dynamic_fields = {
+        "uid": "deadbeef",
+        "meta": {
+            "created": "irrelevant",
+            "updated": "irrelevant",
+            "url": "/d/deadbeef/grafana/tester",
+        },
+    }
+    tester_dashboards = [d.update(update_dynamic_fields) for d in tester_dashboards]
+    assert tester_dashboards[0] == tester_dashboards[1]
+
+    datasource_suffix = "{}_0".format(tester_app_name)
+    datasources_with_relation = await asyncio.gather(
+        get_grafana_datasources(ops_test, grafana_app_name, 0),
+        get_grafana_datasources(ops_test, grafana_app_name, 1),
+    )
+    tester_datasources = [
+        get_datasource_for(datasource_suffix, datasources_with_relation[0]),
+        get_datasource_for(datasource_suffix, datasources_with_relation[1]),
+    ]
+    tester_datasources = [d.update({"uid": "deadbeef"}) for d in tester_datasources]
+    assert tester_datasources[0] != {}
+    assert tester_datasources[0] == tester_datasources[1]
+
+    await ops_test.model.applications[tester_app_name].remove()
+    await ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active")
+
+    relation_removed_dashboards = await asyncio.gather(
+        get_grafana_dashboards(ops_test, grafana_app_name, 0),
+        get_grafana_dashboards(ops_test, grafana_app_name, 1),
+    )
+    relation_removed_datasources = await asyncio.gather(
+        get_grafana_datasources(ops_test, grafana_app_name, 0),
+        get_grafana_datasources(ops_test, grafana_app_name, 1),
+    )
+    relation_removed_dashboards = list(itertools.chain.from_iterable(relation_removed_dashboards))
+    relation_removed_datasources = list(
+        itertools.chain.from_iterable(relation_removed_datasources)
+    )
+    assert initial_dashboards == relation_removed_dashboards
+    assert initial_datasources == relation_removed_datasources
+
+    await ops_test.model.applications[grafana_app_name].remove()
+    await ops_test.model.reset()

--- a/tests/integration/test_multiple_units.py
+++ b/tests/integration/test_multiple_units.py
@@ -43,8 +43,7 @@ async def test_grafana_dashboard_relation_data_with_grafana_tester(
         ),
     )
     await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active"),
-        ops_test.model.wait_for_idle(apps=[tester_app_name], status="active"),
+        ops_test.model.wait_for_idle(apps=[grafana_app_name, tester_app_name], status="active"),
     )
     await ops_test.model.applications[grafana_app_name].scale(scale=2)
     await asyncio.gather(
@@ -56,7 +55,7 @@ async def test_grafana_dashboard_relation_data_with_grafana_tester(
         ),
     )
 
-    # Idle again to ensure the second unit has an ddress
+    # Idle again to ensure the second unit has an address
     await ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active")
 
     assert ops_test.model.applications[grafana_app_name].units[0].workload_status == "active"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -101,6 +101,7 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(GrafanaCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.add_relation("grafana", "grafana")
 
         self.minimal_datasource_hash = hashlib.sha256(
             str(yaml.dump(MINIMAL_DATASOURCES_CONFIG)).encode("utf-8")

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -72,6 +72,11 @@ class ConsumerCharm(CharmBase):
     def version(self):
         return "2.0.0"
 
+    @property
+    def peers(self):
+        """Fetch the peer relation."""
+        return self.model.get_relation("grafana")
+
 
 @patch.object(lzma, "compress", new=lambda x, *args, **kwargs: x)
 @patch.object(lzma, "decompress", new=lambda x, *args, **kwargs: x)
@@ -86,6 +91,7 @@ class TestDashboardConsumer(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin()
+        self.harness.add_relation("grafana", "grafana")
 
     def setup_charm_relations(self):
         """Create relations used by test cases.
@@ -112,7 +118,7 @@ class TestDashboardConsumer(unittest.TestCase):
         return rel_ids
 
     def test_consumer_notifies_on_new_dashboards(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
         self.setup_charm_relations()
         self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
@@ -122,7 +128,7 @@ class TestDashboardConsumer(unittest.TestCase):
             [
                 {
                     "id": "file:tester",
-                    "relation_id": 1,
+                    "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED,
                 }
@@ -130,7 +136,7 @@ class TestDashboardConsumer(unittest.TestCase):
         )
 
     def test_consumer_error_on_bad_template(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
         rels = self.setup_charm_relations()
         self.assertEqual(self.harness.charm._stored.dashboard_events, 1)

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -327,7 +327,7 @@ class TestDashboardConsumer(unittest.TestCase):
             [
                 {
                     "id": "file:tester",
-                    "relation_id": 1,
+                    "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": VARIABLE_DASHBOARD_RENDERED,
                 }
@@ -345,7 +345,7 @@ class TestDashboardConsumer(unittest.TestCase):
             [
                 {
                     "id": "file:tester",
-                    "relation_id": 1,
+                    "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": EXISTING_VARIABLE_DASHBOARD_RENDERED,
                 }

--- a/tests/unit/test_source_consumer.py
+++ b/tests/unit/test_source_consumer.py
@@ -46,6 +46,10 @@ class GrafanaCharm(CharmBase):
             self.source_delete_events,
         )
 
+    def source_by_rel_id(self, rel_id):
+        d = self.grafana_consumer.get_peer_data("sources")
+        return d[str(rel_id)]
+
     def source_events(self, _):
         self._stored.source_events += 1
 
@@ -55,6 +59,11 @@ class GrafanaCharm(CharmBase):
     @property
     def version(self):
         return "2.0.0"
+
+    @property
+    def peers(self):
+        """Fetch the peer relation."""
+        return self.model.get_relation("grafana")
 
 
 class TestSourceConsumer(unittest.TestCase):
@@ -68,6 +77,7 @@ class TestSourceConsumer(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin()
+        self.harness.add_relation("grafana", "grafana")
 
     def setup_charm_relations(self, multi=False):
         """Create relations used by test cases.
@@ -118,7 +128,7 @@ class TestSourceConsumer(unittest.TestCase):
             self.assertIn("url", source)
 
     def test_consumer_notifies_on_new_sources(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 0)
         self.assertEqual(self.harness.charm._stored.source_events, 0)
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation("grafana-source", "prometheus")
@@ -135,14 +145,15 @@ class TestSourceConsumer(unittest.TestCase):
             "url": "http://1.2.3.4:9090",
             "unit": "prometheus/0",
         }
-        sources = self.harness.charm.grafana_consumer._stored.sources[rel_id][0]
+
+        sources = self.harness.charm.source_by_rel_id(rel_id)[0]
 
         self.assertIsNotNone(sources)
         self.assertEqual(dict(sources), completed_data)
         self.assertEqual(self.harness.charm._stored.source_events, 2)
 
     def test_consumer_noop_if_not_leader_on_new_sources(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 0)
         self.assertEqual(self.harness.charm._stored.source_events, 0)
         self.harness.set_leader(False)
         rel_id = self.harness.add_relation("grafana-source", "prometheus")
@@ -155,22 +166,22 @@ class TestSourceConsumer(unittest.TestCase):
         )
 
         with pytest.raises(KeyError):
-            self.harness.charm.grafana_consumer._stored.sources[rel_id]
+            self.harness.charm.source_by_rel_id(rel_id)
         self.assertEqual(self.harness.charm._stored.source_events, 0)
 
     def test_consumer_noop_if_data_is_empty_sources(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 0)
         self.assertEqual(self.harness.charm._stored.source_events, 0)
 
         rel_id = self.harness.add_relation("grafana-source", "prometheus")
         self.harness.update_relation_data(rel_id, "prometheus", {"sources": "{}"})
 
         with pytest.raises(KeyError):
-            self.harness.charm.grafana_consumer._stored.sources[rel_id]
+            self.harness.charm.source_by_rel_id(rel_id)
         self.assertEqual(self.harness.charm._stored.source_events, 1)
 
     def test_consumer_handles_multiple_relations(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 0)
         self.assertEqual(self.harness.charm._stored.source_events, 0)
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation("grafana-source", "prometheus")
@@ -187,7 +198,7 @@ class TestSourceConsumer(unittest.TestCase):
             "url": "http://1.2.3.4:9090",
             "unit": "prometheus/0",
         }
-        sources = self.harness.charm.grafana_consumer._stored.sources[rel_id][0]
+        sources = self.harness.charm.source_by_rel_id(rel_id)[0]
 
         self.assertIsNotNone(sources)
         self.assertEqual(dict(sources), completed_data)
@@ -209,16 +220,15 @@ class TestSourceConsumer(unittest.TestCase):
             "url": "http://2.3.4.5:9090",
             "unit": "other-source/0",
         }
-        sources = self.harness.charm.grafana_consumer._stored.sources[other_rel_id][0]
+        sources = self.harness.charm.source_by_rel_id(other_rel_id)[0]
 
         self.assertIsNotNone(sources)
         self.assertEqual(dict(sources), completed_data)
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 2)
         self.assertEqual(self.harness.charm._stored.source_events, 4)
         self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 2)
 
     def test_consumer_handles_source_removal(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 0)
+        self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 0)
         self.assertEqual(self.harness.charm._stored.source_events, 0)
         self.harness.set_leader(True)
         rel_id = self.harness.add_relation("grafana-source", "prometheus")
@@ -235,7 +245,7 @@ class TestSourceConsumer(unittest.TestCase):
             "url": "http://1.2.3.4:9090",
             "unit": "prometheus/0",
         }
-        sources = self.harness.charm.grafana_consumer._stored.sources[rel_id][0]
+        sources = self.harness.charm.source_by_rel_id(rel_id)[0]
 
         self.assertIsNotNone(sources)
         self.assertEqual(dict(sources), completed_data)
@@ -257,11 +267,10 @@ class TestSourceConsumer(unittest.TestCase):
             "url": "http://2.3.4.5:9090",
             "unit": "other-source/0",
         }
-        sources = self.harness.charm.grafana_consumer._stored.sources[other_rel_id][0]
+        sources = self.harness.charm.source_by_rel_id(other_rel_id)[0]
 
         self.assertIsNotNone(sources)
         self.assertEqual(dict(sources), completed_data)
-        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.sources), 2)
         self.assertEqual(self.harness.charm._stored.source_events, 4)
         self.assertEqual(len(self.harness.charm.grafana_consumer.sources), 2)
 
@@ -304,7 +313,7 @@ class TestSourceConsumer(unittest.TestCase):
                 }
             ]
         }
-        self.harness.set_leader(False)
+        self.harness.set_leader(True)
         self.harness.charm.grafana_consumer._stored.sources = original_source_data
         self.harness.charm.grafana_consumer.upgrade_keys()
         # GrafanaConsumer.sources() actually puts them into a list without rel_id, which is


### PR DESCRIPTION
We can't rely on a peer relation in the aggregator or a provider
charms, so we're left with StoredState there, but get rid of it
from Grafana and the associated Consumer libraries.

Update the tests to match. Since JSON doesn't have a literal
int type, make sure that the relation keys in the tests also are
not bare ints, and that we convert from Stored*