### PR TITLE
Pin markup safe also

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ git+https://github.com/canonical/operator/#egg=ops
 pyyaml
 urllib3
 jinja2 < 3
+markupsafe == 2.0.1
 kubernetes


### PR DESCRIPTION
Jinja <3 (via markupsafe) broke today. See
https://github.com/pallets/jinja/issues/1585#issuecomment-1043892628

As they get further way from Python 3.5, we should either move the
Consumer to a modern version of Python (we know that part of the
library will not need to run on old Ubuntu versions as machine
charms) or pin the whole thing.