### PR TITLE
Pin version of markupsafe to fix build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/canonical/operator/#egg=ops
 pyyaml
 urllib3
-jinja2
+jinja2 < 3
+markupsafe==2.0.1  # pin this for now due to https://github.com/pallets/markupsafe/issues/284
 kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/canonical/operator/#egg=ops
 pyyaml
 urllib3
-jinja2 < 3
+jinja2
 kubernetes


### PR DESCRIPTION
This fixes the error when running the unit tests:

```
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```

This is needed due to a breaking change in the markupsafe module. See https://github.com/pallets/markupsafe/issues/284.

I'm not entirely sure it's the *right* fix. It would probably be better to pin all our dependency versions, but this seems like a good start.