### PR TITLE
Return a meaningful error message instead of exceptions if an old version of the provider is used

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1118,13 +1118,16 @@ class GrafanaDashboardConsumer(Object):
         relation_has_invalid_dashboards = False
 
         for _, (fname, template) in enumerate(templates.items()):
-            decoded_content = _decode_dashboard_content(template["content"])
-
+            decoded_content = None
             content = None
             error = None
             try:
+                decoded_content = _decode_dashboard_content(template["content"])
                 content = Template(decoded_content).render()
                 content = _encode_dashboard_content(_convert_dashboard_fields(content))
+            except lzma.LZMAError as e:
+                error = str(e)
+                relation_has_invalid_dashboards = True
             except json.JSONDecodeError as e:
                 error = str(e.msg)
                 relation_has_invalid_dashboards = True


### PR DESCRIPTION
If there's a very old version of the provider library which uses `zlib` instead of `lzma`, the consumer half of the library did not previously handle it gracefully.

Catch the exception and return a message to the provider.