### PR TITLE
Don't squash specially named datasources

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -564,7 +564,7 @@ def _convert_dashboard_fields(content: str) -> str:
     return json.dumps(dict_content)
 
 
-def _replace_template_fields(
+def _replace_template_fields(  # noqa: C901
     dict_content: dict, datasources: dict, existing_templates: bool
 ) -> dict:
     """Make templated fields get cleaned up afterwards.

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -587,7 +587,7 @@ def _replace_template_fields(  # noqa: C901
         #
         # COS only knows about Prometheus and Loki.
         for panel in panels:
-            if "datasource" not in panel:
+            if "datasource" not in panel or not panel.get("datasource", ""):
                 continue
             if not existing_templates:
                 panel["datasource"] = "${prometheusds}"

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -592,6 +592,9 @@ def _replace_template_fields(
             if not existing_templates:
                 panel["datasource"] = "${prometheusds}"
             else:
+                if panel["datasource"] in replacements.values():
+                    # Already a known template variable
+                    continue
                 # Strip out variable characters and maybe braces
                 ds = re.sub(r"(\$|\{|\})", "", panel["datasource"])
                 replacement = replacements.get(datasources[ds], "")

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -595,6 +595,9 @@ def _replace_template_fields(
                 if panel["datasource"] in replacements.values():
                     # Already a known template variable
                     continue
+                if not panel["datasource"]:
+                    # Don't worry about null values
+                    continue
                 # Strip out variable characters and maybe braces
                 ds = re.sub(r"(\$|\{|\})", "", panel["datasource"])
                 replacement = replacements.get(datasources[ds], "")

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -403,3 +403,23 @@ class TestDashboardConsumer(unittest.TestCase):
                 }
             ],
         )
+
+    def test_consumer_templates_dashboard_and_keeps_datasources(self):
+        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        self.setup_different_dashboard(EXISTING_DATASOURCE_DASHBOARD_TEMPLATE)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
+
+        # Comparing lists of dicts is painful. Convert back to a dict so we can sort
+        # and compare appropriately
+        db_content = json.loads(self.harness.charm.grafana_consumer.dashboards[0]["content"])
+        expected_content = json.loads(EXISTING_DATASOURCE_DASHBOARD_RENDERED)
+
+        db_content["templating"]["list"] = sorted(
+            db_content["templating"]["list"], key=lambda k: k["name"]
+        )
+        expected_content["templating"]["list"] = sorted(
+            expected_content["templating"]["list"], key=lambda k: k["name"]
+        )
+
+        self.assertEqual(db_content, expected_content)

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -126,6 +126,58 @@ EXISTING_VARIABLE_DASHBOARD_RENDERED = json.dumps(
     }
 )
 
+EXISTING_DATASOURCE_DASHBOARD_TEMPLATE = """
+{
+    "panels": [
+        {
+            "data": "label_values(up, juju_unit)",
+            "datasource": "${prometheusds}"
+        },
+        {
+            "data": "label_values(up, juju_unit)",
+            "datasource": "${leave_me_alone}"
+        }
+    ],
+    "templating": {
+        "list": [
+            {
+                "description": null,
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "prometheusds",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "name": "leave_me_alone",
+                "query": "influxdb",
+                "type": "datasource"
+            }
+        ]
+    }
+}
+"""
+
+EXISTING_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
+    {
+        "panels": [
+            {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
+            {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
+        ],
+        "templating": {
+            "list": [d for d in reversed(TEMPLATE_DROPDOWNS)]
+            + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
+        },
+    }
+)
+
 
 class ConsumerCharm(CharmBase):
     _stored = StoredState()


### PR DESCRIPTION
If dashboard templates already have `prometheusds` or `lokids`,
leave them alone