### PR TITLE
Make sure Grafana is up before hitting the API to check password validity

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -651,6 +651,7 @@ class GrafanaCharm(CharmBase):
         """Returns the password for the admin user as an action response."""
         if not self.grafana_service.is_ready:
             event.fail("Grafana is not reachable yet. Please try again in a few minutes")
+            return
         if self.grafana_service.password_has_been_changed(
             self.model.config["admin_user"], self._get_admin_password()
         ):

--- a/src/charm.py
+++ b/src/charm.py
@@ -649,6 +649,12 @@ class GrafanaCharm(CharmBase):
 
     def _on_get_admin_password(self, event: ActionEvent) -> None:
         """Returns the password for the admin user as an action response."""
+        if not self.grafana_service.is_ready:
+            event.set_results(
+                {
+                    "admin-password": "Grafana is not reachable yet. Please try again in a few minutes"
+                }
+            )
         if self.grafana_service.password_has_been_changed(
             self.model.config["admin_user"], self._get_admin_password()
         ):

--- a/src/charm.py
+++ b/src/charm.py
@@ -650,11 +650,7 @@ class GrafanaCharm(CharmBase):
     def _on_get_admin_password(self, event: ActionEvent) -> None:
         """Returns the password for the admin user as an action response."""
         if not self.grafana_service.is_ready:
-            event.set_results(
-                {
-                    "admin-password": "Grafana is not reachable yet. Please try again in a few minutes"
-                }
-            )
+            event.fail("Grafana is not reachable yet. Please try again in a few minutes")
         if self.grafana_service.password_has_been_changed(
             self.model.config["admin_user"], self._get_admin_password()
         ):


### PR DESCRIPTION
Since an HTTPError is also checked for in the password action, it's
possible to encounter a race where the action informs users that the
password has been changed when Grafana is simply not available yet.

No tests since Harness cannot check actions and we can't reliably reproduce a race in the integration tests.