### PR TITLE
Adds config to enable auth proxy

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,3 +29,10 @@ options:
       host or a bare A record, this may be omitted.
     type: string
     default: ""
+  enable_auth_proxy:
+    description: |
+      You can configure Grafana to let a HTTP reverse proxy handle authentication. Popular web 
+      servers have a very extensive list of pluggable authentication modules, and any of them can 
+      be used with the AuthProxy feature.
+    type: boolean
+    default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -418,7 +418,7 @@ class GrafanaCharm(CharmBase):
         Creates the configuration file content depending on the various configurations either set
         by users or through relationship data.
         """
-        config = configparser.ConfigParser()
+        config = {}
         if self.has_db:
             config["database"] = self._generate_database_config()
         if self.auth_proxy_enabled:
@@ -426,8 +426,11 @@ class GrafanaCharm(CharmBase):
         return self._generate_config_ini_string(config)
 
     @staticmethod
-    def _generate_config_ini_string(config: configparser.ConfigParser) -> str:
+    def _generate_config_ini_string(config_dict: dict) -> str:
         """Converts configparser data to string."""
+        config = configparser.ConfigParser()
+        for key, value in config_dict.items():
+            config[key] = value
         data = StringIO()
         config.write(data)
         data.seek(0)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -192,11 +192,11 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.set_leader(True)
 
-        self.harness.update_config({"enable_auth_proxy": True})
+        self.harness.update_config({"enable_auth_proxy": "True"})
 
         config = self.harness.charm.container.pull(CONFIG_PATH)
         config_parser = configparser.ConfigParser()
-        config_parser.read_file(config)
+        config_parser.read_file(config)  # type: ignore[arg-type]
         assert config_parser["auth.proxy"]["enabled"] == "true"
         assert config_parser["auth.proxy"]["header_name"] == "X-WEBAUTH-USER"
         assert config_parser["auth.proxy"]["header_property"] == "username"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -192,12 +192,25 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.set_leader(True)
 
-        self.harness.update_config({"enable_auth_proxy": "True"})
+        self.harness.update_config({"enable_auth_proxy": True})  # type: ignore[dict-item]
 
         config = self.harness.charm.container.pull(CONFIG_PATH)
         config_parser = configparser.ConfigParser()
         config_parser.read_file(config)  # type: ignore[arg-type]
+        assert "auth.proxy" in config_parser
         assert config_parser["auth.proxy"]["enabled"] == "true"
         assert config_parser["auth.proxy"]["header_name"] == "X-WEBAUTH-USER"
         assert config_parser["auth.proxy"]["header_property"] == "username"
         assert config_parser["auth.proxy"]["auto_sign_up"] == "false"
+
+    def test_given_auth_proxy_config_is_disabled_when_update_config_then_grafana_config_file_doesnt_contain_auth_proxy_data(
+        self,
+    ):
+        self.harness.set_leader(True)
+
+        self.harness.update_config({"enable_auth_proxy": False})  # type: ignore[dict-item]
+
+        config = self.harness.charm.container.pull(CONFIG_PATH)
+        config_parser = configparser.ConfigParser()
+        config_parser.read_file(config)  # type: ignore[arg-type]
+        assert "auth.proxy" not in config_parser

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -187,6 +187,16 @@ class TestCharm(unittest.TestCase):
         self.assertIn("GF_SERVER_SERVE_FROM_SUB_PATH", services["environment"].keys())
         self.assertTrue(services["environment"]["GF_SERVER_ROOT_URL"].endswith("/grafana"))
 
+    def test_given_no_config_when_update_config_then_grafana_config_file_is_empty(self):
+        self.harness.set_leader(True)
+
+        self.harness.update_config()
+
+        config = self.harness.charm.container.pull(CONFIG_PATH)
+        config_parser = configparser.ConfigParser()
+        config_parser.read_file(config)  # type: ignore[arg-type]
+        assert len(config_parser.sections()) == 0
+
     def test_given_auth_proxy_config_is_enabled_when_update_config_then_grafana_config_file_contains_auth_proxy_data(
         self,
     ):


### PR DESCRIPTION
Adds config to enable auth proxy
- Adds config for Grafana to let a HTTP reverse proxy handle authentication.
- Improves how Grafana's configuration file is generated based on Juju configs and relationship data

Explanation:
- Auth proxy is used in Magma where Grafana is shown within the application's UI frame and authentications is handled by passport.

Reference:
- Auth proxy authentication: https://grafana.com/docs/grafana/latest/auth/auth-proxy/