### PR TITLE
cleanup automation and use current versions

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -6,15 +6,21 @@ on:
       - main
 
 jobs:
-  fetch-lib-check:
-    name: Check the charm uses up-to-date charm libraries
+  lib-check:
+    name: Check libraries
     runs-on: ubuntu-latest
     steps:
-    - name: Check libs
-      uses: canonical/charm-lib-checker-action@main
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-  lib-check:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.1-rc
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  static-libs:
     name: Static analysis of /lib for Python 3.5
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +36,7 @@ jobs:
       run: python3 -m pip install tox
     - name: Run static analysis for /lib for 3.5
       run: tox -vve static-lib
+
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest
@@ -46,6 +53,7 @@ jobs:
       run: tox -vve static-unit
     - name: Run static analysis (integration tests)
       run: tox -vve static-integration
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -65,6 +73,7 @@ jobs:
       run: python3 -m pip install tox
     - name: Run linters
       run: tox -vve lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -84,7 +93,8 @@ jobs:
       run: python -m pip install tox
     - name: Run tests
       run: tox -e unit
-  integration-test-microk8s:
+
+  integration-test:
     name: Integration tests (microk8s)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -1,4 +1,4 @@
-name: Release to edge
+name: Release to Edge
 
 on:
   push:
@@ -6,46 +6,54 @@ on:
       - main
 
 jobs:
-  fetch-lib-check:
-    name: Check the charm uses up-to-date charm libraries
+  lib-check:
+    name: Check libraries
     runs-on: ubuntu-latest
     steps:
-    - name: Check libs
-      uses: canonical/charm-lib-checker-action@main
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-  lib-check:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.1-rc
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  static-libs:
     name: Static analysis of /lib for Python 3.5
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.5
-    - name: Install dependencies
-      run: python3 -m pip install tox
-    - name: Run static analysis for /lib for 3.5
-      run: tox -vve static-lib
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.5
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.5
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run static analysis for /lib for 3.5
+        run: tox -vve static-lib
+
   static-analysis:
     name: Static analysis
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install dependencies
-      run: python3 -m pip install tox
-    - name: Run static analysis (charm)
-      run: tox -vve static-charm
-    - name: Run static analysis (unit tests)
-      run: tox -vve static-unit
-    - name: Run static analysis (integration tests)
-      run: tox -vve static-integration
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run static analysis (charm)
+        run: tox -vve static-charm
+      - name: Run static analysis (unit tests)
+        run: tox -vve static-unit
+      - name: Run static analysis (integration tests)
+        run: tox -vve static-integration
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -53,18 +61,19 @@ jobs:
       matrix:
         python: [3.8]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install dependencies
-      run: python3 -m pip install tox
-    - name: Run linters
-      run: tox -vve lint
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -vve lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -72,38 +81,40 @@ jobs:
       matrix:
         python-version: [3.8]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up python ${{ matrix.python }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install dependencies
-      run: python -m pip install tox
-    - name: Run tests
-      run: tox -e unit
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e unit
+
   integration-test:
     name: Integration tests (microk8s)
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
-      with:
-        juju-channel: latest/candidate # FIXME: Once 2.9.23 hits stable
-        provider: microk8s
-    - name: Run integration tests
-      run: tox -vve integration
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: latest/candidate # FIXME: Once 2.9.23 hits stable
+          provider: microk8s
+      - name: Run integration tests
+        run: tox -vve integration
+
   release-to-charmhub:
     name: Release to CharmHub
     needs:
       - static-analysis
-      - lib-check
+      - static-libs
       - lint
       - unit-test
       - integration-test
@@ -113,20 +124,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Upload to edge channel
-        uses: canonical/charmhub-upload-action@0.2.0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@1.0.1-rc
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@1.0.1-rc
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-      - name: Get Revision ID
-        id: revision
-        run: |
-          echo "::set-output name=rev::$(charmcraft status grafana-k8s | grep edge | awk '{print $2}')"
-      - name: Create tag
-        uses: actions/create-release@v1
-        with:
-          draft: false
-          prerelease: false
-          release_name: Revision ${{ steps.revision.outputs.rev }}
-          tag_name: rev${{ steps.revision.outputs.rev }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"


### PR DESCRIPTION
### Changes
- Replaces the legacy library check with the one provided by charming-actions.
- Replaces the legacy tagging mechanism with the one from charming-actions.
- Harmonizes the job names to match our other repositories.

### Test Instructions
- Verify that the workflow passes for the PR.
- Verify that the release on Charmhub is still valid after the release workflow has finished.