### PR TITLE
Add support for unit ingresses to GrafanaSourceProvider

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -533,11 +533,15 @@ class GrafanaSourceConsumer(Object):
                 unit_name.split("/")[1],
             )
 
+            host = (
+                "http://{}".format(host_addr) if not re.match(r"^\w+://", host_addr) else host_addr
+            )
+
             host_data = {
                 "unit": unit_name,
                 "source_name": unique_source_name,
                 "source_type": source_data["type"],
-                "url": "http://{}".format(host_addr),
+                "url": host,
             }
 
             if host_data["source_name"] in sources_to_delete:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -29,9 +29,13 @@ The default arguments are:
     `refresh_event`: A `PebbleReady` event from `charm`, used to refresh
         the IP address sent to Grafana on a charm lifecycle event or
         pod restart
-    `source_type`: prometheus
-    `source_port`: 9090
+    `source_type`: ""
+    `source_port`: ""
     `source_uri`: ""
+
+`source_uri` should be a fully-resolvable URI for a valid Grafana source.
+As only HTTP sources are supported via libraries in the current charm, this
+is likely to be `http://example.com/api` or similar.
 
 If your configuration requires any changes from these defaults, they
 may be set from the class constructor. It may be instantiated as
@@ -315,8 +319,8 @@ class GrafanaSourceProvider(Object):
         charm: CharmBase,
         refresh_event: Optional[BoundEvent] = None,
         relation_name: str = DEFAULT_RELATION_NAME,
-        source_type: Optional[str] = "prometheus",
-        source_port: Optional[str] = "9090",
+        source_type: Optional[str] = "",
+        source_port: Optional[str] = "",
         source_uri: Optional[str] = "",
     ) -> None:
         """Construct a Grafana charm client.
@@ -354,7 +358,8 @@ class GrafanaSourceProvider(Object):
                 required for Grafana configuration.
             source_uri: an optional source uri which can be used if ingress for
                 a source is enabled, the source is in a different namespace, or
-                a path must be specified for another reason.
+                a path must be specified for another reason. If set, 'source_port'
+                will not be used.
         """
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -397,6 +397,10 @@ class GrafanaSourceProvider(Object):
         if refresh_event:
             self.framework.observe(refresh_event, self._set_unit_details)
 
+    def update_source(self):
+        """Trigger the update of relation data."""
+        self._set_sources(None)  # type: ignore
+
     def _set_sources(self, event: RelationJoinedEvent):
         """Inform the consumer about the source configuration."""
         self._set_unit_details(event)

--- a/tests/integration/grafana-tester/src/charm.py
+++ b/tests/integration/grafana-tester/src/charm.py
@@ -21,7 +21,7 @@ class GrafanaTesterCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self._name = "grafana-tester"
-        self.grafana_source = GrafanaSourceProvider(self, self.on.grafana_tester_pebble_ready)
+        self.grafana_source = GrafanaSourceProvider(self, source_type="prometheus")
         self.grafana_dashboard = GrafanaDashboardProvider(self)
         self.framework.observe(
             self.on.grafana_tester_pebble_ready, self._on_grafana_tester_pebble_ready

--- a/tests/unit/test_source_provider.py
+++ b/tests/unit/test_source_provider.py
@@ -32,7 +32,10 @@ class ProviderCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.provider = GrafanaSourceProvider(
-            self, refresh_event=self.on.grafana_tester_pebble_ready, source_port="9090"
+            self,
+            source_type="foobar",
+            source_port="9090",
+            refresh_event=self.on.grafana_tester_pebble_ready,
         )
 
 
@@ -110,8 +113,9 @@ class TestSourceProviderWithIngress(unittest.TestCase):
     def test_provider_unit_sets_source_uri_if_provided(self):
         self.harness.charm.provider = GrafanaSourceProvider(
             self.harness.charm,
+            source_type="foobar",
+            source_url="http://1.2.3.4/v1",
             refresh_event=self.harness.charm.on.grafana_tester_pebble_ready,
-            source_uri="http://1.2.3.4/v1",
         )
         rel_id = self.harness.add_relation("grafana-source", "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
@@ -122,8 +126,9 @@ class TestSourceProviderWithIngress(unittest.TestCase):
     def test_provider_unit_sets_scheme_if_not_provided(self):
         self.harness.charm.provider = GrafanaSourceProvider(
             self.harness.charm,
+            source_type="foobar",
+            source_url="1.2.3.4/v1",
             refresh_event=self.harness.charm.on.grafana_tester_pebble_ready,
-            source_uri="1.2.3.4/v1",
         )
         rel_id = self.harness.add_relation("grafana-source", "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
@@ -137,7 +142,7 @@ class ProviderCharmNoRefreshEvent(CharmBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
-        self.provider = GrafanaSourceProvider(self)
+        self.provider = GrafanaSourceProvider(self, source_type="foobar")
 
         self._stored.set_default(valid_events=0)  # available data sources
         self._stored.set_default(invalid_events=0)

--- a/tests/unit/test_source_provider.py
+++ b/tests/unit/test_source_provider.py
@@ -131,3 +131,22 @@ class TestSourceProviderWithIngress(unittest.TestCase):
         data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
         self.assertIn("grafana_source_host", data)
         self.assertEqual(data["grafana_source_host"], "http://1.2.3.4/v1")
+
+
+class ProviderCharmNoRefreshEvent(CharmBase):
+    _stored = StoredState()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        self.provider = GrafanaSourceProvider(self)
+
+        self._stored.set_default(valid_events=0)  # available data sources
+        self._stored.set_default(invalid_events=0)
+
+
+class TestDashboardProviderNoRefreshEvent(unittest.TestCase):
+    def test_provider_instantiates_correctly(self):
+        self.harness = Harness(ProviderCharmNoRefreshEvent, meta=CONSUMER_META)
+        self.harness.begin_with_initial_hooks()
+
+        self.harness.container_pebble_ready("grafana-tester")

--- a/tests/unit/test_source_provider.py
+++ b/tests/unit/test_source_provider.py
@@ -32,8 +32,7 @@ class ProviderCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.provider = GrafanaSourceProvider(
-            self,
-            refresh_event=self.on.grafana_tester_pebble_ready,
+            self, refresh_event=self.on.grafana_tester_pebble_ready, source_port="9090"
         )
 
 


### PR DESCRIPTION
## Issue
Previously, `GrafanaSourceProvider` only supported connecting directly
to the root URL, so some source (let's say Prometheus) was no longer
accessible once ingress was enabled.

## Solution
A new argument was added to the constructor to allow specifying `source_uri`,
which will be used. If both `source_uri` and `source_port` are specified, a warning
will be emitted. If no scheme is set (such as `http://`), a warning will be emitted, and
the scheme added, so it is clear whether HTTP, HTTPS, or something else should
be used.

## Context
None.

## Testing Instructions
Enable ingress for Prometheus. Instantiate the Provider with the ingress path. Ensure
that it's usable from Grafana. 

Since the Provider Charm is aware of whether or not subpath routing needs to be used
if an ingress is set, even if it's an in-model connection, the Providing charm decides
whether or not to set this argument based on context. A PR is available for Prometheus

## Release Notes
Add support for unit ingresses/source paths  to GrafanaSourceProvider