### PR TITLE
Update to the latest Grafana Rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,4 +40,4 @@ resources:
   grafana-image:
     type: oci-image
     description: upstream docker image for Grafana
-    upstream-source: docker.io/ubuntu/grafana@sha256:8952155a72868b609e6b2e5ac5d20c540b232380f17dcf8aa60ac04b234edf9c
+    upstream-source: docker.io/ubuntu/grafana@sha256:86c77082f25b4bce37df37fb1fb1c351477902c59481369b71ba2d328e98d793


### PR DESCRIPTION
## Issue

Update to the [latest Grafana Rock](https://hub.docker.com/layers/grafana/ubuntu/grafana/latest/images/sha256-86c77082f25b4bce37df37fb1fb1c351477902c59481369b71ba2d328e98d793?context=explore).

## Solution

Update the `upstream-source` in `metadata.yaml`.

## Context

New LTS, new ROCK, must-have.

## Testing Instructions

Usual manual tests with a `cos-lite` deployment.

## Release Notes

Update the Grafana container image to the latest ROCK based on Ubuntu 22.04.