### PR TITLE
Replace bind_address with fqdn

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -128,6 +128,7 @@ events may not be needed.
 import json
 import logging
 import re
+import socket
 from typing import Any, Dict, List, Optional, Union
 
 from ops.charm import (
@@ -446,22 +447,8 @@ class GrafanaSourceProvider(Object):
         unit relation data for the Prometheus consumer.
         """
         for relation in self._charm.model.relations[self._relation_name]:
-            # network.bind_address can return `None` and give us a bad string, so make sure
-            # that it's valid before passing it. Otherwise, we'll catch is on pebble_ready.
-            # The provider side already skips adding it if `grafana_source_host` is not set,
-            # so no additional guards needed
-            url = None
-            if self._source_url:
-                url = self._source_url
-            else:
-                address = self._charm.model.get_binding(relation).network.bind_address
-                if address:
-                    url = "{}:{}".format(str(address), self._source_port)
-
-            # If _source_url was not set in the constructor and there are no units in the
-            # relation or pebble or address was not bound, this may not be set
-            if url:
-                relation.data[self._charm.unit]["grafana_source_host"] = url
+            url = self._source_url or "{}:{}".format(socket.getfqdn(), self._source_port)
+            relation.data[self._charm.unit]["grafana_source_host"] = url
 
 
 class GrafanaSourceConsumer(Object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops
 pyyaml
 urllib3
 jinja2 < 3


### PR DESCRIPTION
## Issue
`bind_address` sometimes returns None. Recently observed during load test.

Crossref: [OPENG-785](https://warthogs.atlassian.net/browse/OPENG-785)


## Solution
Use `socket.getfqdn` instead of `bind_address`.


## Context
NTA


## Testing Instructions
Run integration tests.


## Release Notes
Replace bind_address with fqdn.