### PR TITLE
Enable alpha plugins to allow Alertmanager datasources

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -551,6 +551,7 @@ class GrafanaCharm(CharmBase):
                         "environment": {
                             "GF_SERVER_HTTP_PORT": PORT,
                             "GF_LOG_LEVEL": self.model.config["log_level"],
+                            "GF_PLUGINS_ENABLE_ALPHA": True,
                             "GF_PATHS_PROVISIONING": PROVISIONING_PATH,
                             "GF_SECURITY_ADMIN_USER": self.model.config["admin_user"],
                             "GF_SECURITY_ADMIN_PASSWORD": self._get_admin_password(),


### PR DESCRIPTION
## Issue
Enable alpha plugins to allow for Alertmanager datasources.

Until Grafana 9, Alertmanager is not natively supported.

Closes #101 

## Release Notes
Enable alpha plugins to allow Alertmanager datasources