### PR TITLE
Datasource Query timeout Configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,3 +29,13 @@ options:
       host or a bare A record, this may be omitted.
     type: string
     default: ""
+  datasource_query_timeout:
+    description: |
+      The default timeout for querying a Grafana datasource. Each datasource can
+      also configure its own preferred timeout value through relation data. If the
+      value configured through relation data is larger than datasource_query_timeout
+      then that value is left unchanged. The value of this configuration option must
+      be a positive integer representing the maximum number of seconds Grafana will
+      wait for a datasource to respond to a query.
+    type: int
+    default: 300

--- a/src/charm.py
+++ b/src/charm.py
@@ -640,6 +640,15 @@ class GrafanaCharm(CharmBase):
             }
             if source_info.get("extra_fields", None):
                 source["jsonData"] = source_info.get("extra_fields")
+
+            # set timeout for querying this data source
+            timeout = source.get("jsonData", {}).get("timeout", 0)
+            configured_timeout = self.model.config.get("datasource_query_timeout")
+            if timeout < configured_timeout:
+                json_data = source.get("jsonData", {})
+                json_data.update({"timeout": configured_timeout})
+                source["jsonData"] = json_data
+
             datasources_dict["datasources"].append(source)  # type: ignore[attr-defined]
 
         # Also get a list of all the sources which have previously been purged and add them


### PR DESCRIPTION
## Issue
Queries issued by Grafana to data sources may sometimes take long time to complete. In such cases it is possible Grafana can timeout waiting for the response leading to a 5xx HTTP error. 


## Solution
The PR adds a configuration option `datasource_query_timeout" to the Grafana charm. This option is used to set a default maximum number of seconds Grafana will wait for a query response. This maximum value may be overridden by any particular data source (using its relation data) if it needs to set and even larger value.


## Context
Same as above.


## Testing Instructions
- Deploy Grafana
- Add a data source
- Check the data source has a default timeout value set as shown in the image below
- Add another data source which uses a larger timeout value than the value set by Grafana's configuration option
- Check that the data sources larger timeout value is honored.

![Screenshot from 2022-07-18 11-51-04](https://user-images.githubusercontent.com/1672069/179512578-796c1813-5b7f-48b5-af6f-1e00eae39562.png)


## Release Notes
- Data source query timeout is now configurable
