### PR TITLE
Use asyncio_mode='auto' or async fixtures don't actually run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ allow_redefinition = true
 [[tool.mypy.overrides]]
 module = ["ops.*", "pytest.*", "pytest_operator.*", "urllib3.*"]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,6 @@ deps =
     asyncstdlib
     juju
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    pytest-operator
 commands =
     pytest -v --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
## Issue
Fix integration tests not awaiting fixtures, and instead trying to deploy a `coroutine`

Unpin `pytest-operator` while we're at it.
