### PR TITLE
Upkeep

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.1-rc
+        uses: canonical/charming-actions/check-libraries@2.0.0-rc2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -492,6 +492,7 @@ class GrafanaCharm(CharmBase):
     def _on_pebble_ready(self, event) -> None:
         """When Pebble is ready, start everything up."""
         self._configure()
+        self.unit.set_workload_version(self.grafana_version)
 
     def restart_grafana(self) -> None:
         """Restart the pebble container.

--- a/src/charm.py
+++ b/src/charm.py
@@ -492,7 +492,8 @@ class GrafanaCharm(CharmBase):
     def _on_pebble_ready(self, event) -> None:
         """When Pebble is ready, start everything up."""
         self._configure()
-        self.unit.set_workload_version(self.grafana_version)
+        if version := self.grafana_version:
+            self.unit.set_workload_version(version)
 
     def restart_grafana(self) -> None:
         """Restart the pebble container.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import yaml
 from ops.testing import Harness
 
+import grafana_server
 from charm import CONFIG_PATH, DATASOURCES_PATH, PROVISIONING_PATH, GrafanaCharm
 
 MINIMAL_CONFIG = {"grafana-image-path": "grafana/grafana", "port": 3000}
@@ -263,3 +264,9 @@ class TestCharm(unittest.TestCase):
         expected_source_data = BASIC_DATASOURCES.copy()
         expected_source_data[0]["jsonData"]["timeout"] = 300
         self.assertEqual(yaml.safe_load(config).get("datasources"), expected_source_data)
+
+    @k8s_resource_multipatch
+    @patch.object(grafana_server.Grafana, "build_info", new={"version": "1.0.0"})
+    def test_workload_version_is_set(self):
+        self.harness.container_pebble_ready("grafana")
+        self.assertEqual(self.harness.get_workload_version(), "1.0.0")


### PR DESCRIPTION
## Issue
General charm upkeep.


## Solution
Update the "check-libraries" action and set workload_version.


## Testing Instructions
Deploy and check workload version is set.


## Release Notes
grafana-k8s now sets workload version
