### PR TITLE
Update unit name in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ jinja2 < 3
 kubernetes
 lightkube >= 0.11
 markupsafe == 2.0.1
-ops
+git+https://github.com/canonical/operator/#egg=ops
 pyyaml
 urllib3

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -310,7 +310,7 @@ class TestCharmReplication(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.charm.on.config_changed.emit()
         rel = self.harness.model.get_relation("grafana")
-        self.harness.add_relation_unit(rel.id, "grafana/1")
+        self.harness.add_relation_unit(rel.id, "grafana-k8s/1")
 
         unit_ip = str(self.harness.charm.model.get_binding("grafana").network.bind_address)
         replica_address = self.harness.charm.get_peer_data("replica_primary")
@@ -331,7 +331,7 @@ class TestCharmReplication(unittest.TestCase):
         mock_unit_ip.return_value = fake_network
         self.harness.set_leader(False)
         rel = self.harness.model.get_relation("grafana")
-        self.harness.add_relation_unit(rel.id, "grafana/1")
+        self.harness.add_relation_unit(rel.id, "grafana-k8s/1")
         self.harness.update_relation_data(
             rel.id, "grafana-k8s", {"replica_primary": json.dumps("1.2.3.4")}
         )


### PR DESCRIPTION
Name validation was recently added to add_relation_unit ([here]),
so we must update the remote unit name used here.
Besides that, it's probably best to be consistent with naming here - I guess there was a recent change from grafana to grafana-k8s, so this would have been easily missed.

Note that unittests were passing here,
but would otherwise fail once `ops` released a new update.

[here]: https://github.com/canonical/operator/pull/795/files#diff-37e8d80748bba21bb08c982f17b7879059bacc8d413b59da998a896fca18be33R712-R717

## Issue
<!-- What issue is this PR trying to solve? -->

Resolving this test failure on operator: https://github.com/canonical/operator/runs/8109846894  (`operator` has tests that run unit tests on selected charms, with the `ops` dependency installed at the latest revision) 

## Solution
<!-- A summary of the solution addressing the above issue -->
see description above

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions

- install ops latest master from git: `git+https://github.com/canonical/operator/#egg=ops`
- run `tox -e unit`

This should fail on grafana-k8s-operator master, but pass on this branch.


## Release Notes
<!-- A digestable summary of the change in this PR -->
