### PR TITLE
use binary to get workload version

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import socket
 import string
@@ -566,8 +567,13 @@ class GrafanaCharm(CharmBase):
     def _on_pebble_ready(self, event) -> None:
         """When Pebble is ready, start everything up."""
         self._configure()
-        if version := self.grafana_version:
+        version = self.grafana_version
+        if version is not None:
             self.unit.set_workload_version(version)
+        else:
+            logger.debug(
+                "Cannot set workload version at this time: could not get Alertmanager version."
+            )
 
     def restart_grafana(self) -> None:
         """Restart the pebble container.
@@ -746,11 +752,21 @@ class GrafanaCharm(CharmBase):
 
     @property
     def grafana_version(self):
-        """Grafana server version."""
-        info = self.grafana_service.build_info
-        if info:
-            return info.get("version", None)
-        return None
+        """Grafana server version.
+
+        Returns:
+            A string equal to the Grafana server version.
+        """
+        container = self.containers["workload"]
+        if not container.can_connect():
+            return None
+        version_output, _ = container.exec(["grafana-server", "-v"]).wait_output()
+        # Output looks like this:
+        # Version 8.2.6 (commit: d2cccfe, branch: HEAD)
+        result = re.search(r"Version (\d*\.\d*\.\d*)", version_output)
+        if result is None:
+            return result
+        return result.group(1)
 
     @property
     def grafana_config_ini_hash(self) -> str:

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+class FakeProcessVersionCheck:
+    def __init__(self, args):
+        pass
+
+    def wait_output(self):
+        return ("Version 0.1.0", "")
+
+    def wait(self):
+        return

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,9 +8,10 @@ import unittest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import yaml
+from helpers import FakeProcessVersionCheck
+from ops.model import Container
 from ops.testing import Harness
 
-import grafana_server
 from charm import CONFIG_PATH, DATASOURCES_PATH, PROVISIONING_PATH, GrafanaCharm
 
 MINIMAL_CONFIG = {"grafana-image-path": "grafana/grafana", "port": 3000}
@@ -272,10 +273,10 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(yaml.safe_load(config).get("datasources"), expected_source_data)
 
     @k8s_resource_multipatch
-    @patch.object(grafana_server.Grafana, "build_info", new={"version": "1.0.0"})
+    @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def test_workload_version_is_set(self):
         self.harness.container_pebble_ready("grafana")
-        self.assertEqual(self.harness.get_workload_version(), "1.0.0")
+        self.assertEqual(self.harness.get_workload_version(), "0.1.0")
 
 
 class TestCharmReplication(unittest.TestCase):


### PR DESCRIPTION
## Issue
setting workload version could fail if Grafana is not ready yet.


## Solution
Run the binary to get the version.


## Testing Instructions
Check workload version is set.


## Release Notes
grafana-k8s sets workload version more reliably
