### PR TITLE
Keep dashboards and datasources after deletion/reboot

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1097,7 +1097,7 @@ class GrafanaDashboardConsumer(Object):
             return
         self.on.dashboards_changed.emit()
 
-    def update_dashboards(self, relation: Relation = None) -> None:
+    def update_dashboards(self, relation: Optional[Relation] = None) -> None:
         """Re-establish dashboards on one or more relations.
 
         If something changes between this library and a datasource, try to re-establish
@@ -1108,7 +1108,6 @@ class GrafanaDashboardConsumer(Object):
                 updated. If not specified, all relations managed by this
                 :class:`GrafanaDashboardConsumer` will be updated.
         """
-        changes = False
         if self._charm.unit.is_leader():
             relations = (
                 [relation] if relation else self._charm.model.relations[self._relation_name]
@@ -1116,9 +1115,6 @@ class GrafanaDashboardConsumer(Object):
 
             for relation in relations:
                 self._render_dashboards_and_signal_changed(relation)
-
-        if changes:
-            self.on.dashboards_changed.emit()
 
     def _on_grafana_dashboard_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Update job config when providers depart.

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -507,7 +507,7 @@ class GrafanaSourceConsumer(Object):
             self._on_grafana_peer_changed,
         )
 
-    def _on_grafana_source_relation_changed(self, event: CharmEvents) -> None:
+    def _on_grafana_source_relation_changed(self, event: Optional[CharmEvents] = None) -> None:
         """Handle relation changes in related providers.
 
         If there are changes in relations between Grafana source consumers
@@ -676,6 +676,20 @@ class GrafanaSourceConsumer(Object):
             peer_sources_to_delete = set(self.get_peer_data("sources_to_delete"))
             sources_to_delete = set.union(old_sources_to_delete, peer_sources_to_delete)
             self.set_peer_data("sources_to_delete", sources_to_delete)
+
+    def update_sources(self, relation: Relation = None) -> None:
+        """Re-establish sources on one or more relations.
+
+        If something changes between this library and a datasource, try to re-establish
+        datasources.
+
+        Args:
+            relation: a specific relation for which the datasources have to be
+                updated. If not specified, all relations managed by this
+                :class:`GrafanaSourceConsumer` will be updated.
+        """
+        if self._charm.unit.is_leader():
+            self._on_grafana_source_relation_changed(None)
 
     @property
     def sources(self) -> List[dict]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -334,6 +334,7 @@ class GrafanaCharm(CharmBase):
             event: a :class:`UpgradeCharmEvent` to signal the upgrade
         """
         self.source_consumer.upgrade_keys()
+        self.dashboard_consumer.update_dashboards()
         self._configure()
         self._on_dashboards_changed(event)
 
@@ -671,6 +672,8 @@ class GrafanaCharm(CharmBase):
     def _on_pebble_ready(self, event) -> None:
         """When Pebble is ready, start everything up."""
         self._configure()
+        self.source_consumer.upgrade_keys()
+        self.dashboard_consumer.update_dashboards()
         version = self.grafana_version
         if version is not None:
             self.unit.set_workload_version(version)

--- a/src/charm.py
+++ b/src/charm.py
@@ -326,6 +326,7 @@ class GrafanaCharm(CharmBase):
             if container.list_files(dashboards_dir_path, pattern="grafana_metrics.json"):
                 container.remove_path(dashboard_path)
                 logger.debug("Removed dashboard %s", dashboard_path)
+                self.restart_grafana()
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         """Re-provision Grafana and its datasources on upgrade.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -177,6 +177,7 @@ async def get_dashboard_by_search(
     pw = await grafana_password(ops_test, app_name)
     grafana = Grafana(host=host, pw=pw)
     dashboards = await grafana.dashboard_search(query_string)
+
     dashboard_json = await grafana.fetch_dashboard(dashboards[0]["uid"])
     return dashboard_json
 
@@ -217,7 +218,7 @@ def oci_image(metadata_file: str, image_name: str) -> str:
 async def get_config_values(ops_test, app_name) -> dict:
     """Return the app's config, but filter out keys that do not have a value."""
     config = await ops_test.model.applications[app_name].get_config()
-    return {key: config[key]["value"] for key in config if "value" in config[key]}
+    return {key: str(config[key]["value"]) for key in config if "value" in config[key]}
 
 
 async def get_grafana_environment_variable(

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -2,19 +2,32 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
+import asyncio
 import logging
 
 import pytest
-from helpers import check_grafana_is_ready, get_config_values, oci_image
+from helpers import (
+    check_grafana_is_ready,
+    get_config_values,
+    get_dashboard_by_search,
+    get_datasource_for,
+    get_grafana_datasources,
+    oci_image,
+)
 
 logger = logging.getLogger(__name__)
 
-app_name = "grafana"
+grafana_app_name = "grafana"
+tester_app_name = "grafana-tester"
 config = {"log_level": "error", "admin_user": "jimmy"}
 grafana_resources = {
     "grafana-image": oci_image("./metadata.yaml", "grafana-image"),
     "litestream-image": oci_image("./metadata.yaml", "litestream-image"),
+}
+tester_resources = {
+    "grafana-tester-image": oci_image(
+        "./tests/integration/grafana-tester/metadata.yaml", "grafana-tester-image"
+    )
 }
 
 
@@ -23,17 +36,54 @@ async def test_deploy_from_local_path(ops_test, grafana_charm):
     """Deploy the charm-under-test."""
     logger.debug("deploy local charm")
 
-    await ops_test.model.deploy(
-        grafana_charm, application_name=app_name, resources=grafana_resources, trust=True
+    await asyncio.gather(
+        ops_test.model.deploy(
+            grafana_charm,
+            resources=grafana_resources,
+            application_name=grafana_app_name,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            grafana_charm,
+            application_name=grafana_app_name,
+            resources=grafana_resources,
+            trust=True,
+        ),
     )
 
     # set some custom configs to later check they persisted across the test
-    await ops_test.model.applications[app_name].set_config(config)
-    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
+    await ops_test.model.applications[grafana_app_name].set_config(config)
+    await ops_test.model.wait_for_idle(
+        apps=[grafana_app_name, tester_app_name], status="active", timeout=1000
+    )
+
+
+async def test_create_and_check_datasource_and_dashboard_before_delete(ops_test):
+    await asyncio.gather(
+        ops_test.model.add_relation(
+            "{}:grafana-source".format(grafana_app_name),
+            "{}:grafana-source".format(tester_app_name),
+        ),
+        ops_test.model.add_relation(
+            "{}:grafana-dashboard".format(grafana_app_name),
+            "{}:grafana-dashboard".format(tester_app_name),
+        ),
+    )
+    await ops_test.model.wait_for_idle(apps=[grafana_app_name], status="active")
+
+    tester_dashboard = await get_dashboard_by_search(
+        ops_test, grafana_app_name, 0, "Grafana Tester"
+    )
+    assert tester_dashboard != {}
+
+    datasource_suffix = "{}_0".format(tester_app_name)
+    datasources_with_relation = await get_grafana_datasources(ops_test, grafana_app_name, 0)
+    tester_datasource = get_datasource_for(datasource_suffix, datasources_with_relation)
+    assert tester_datasource != {}
 
 
 async def test_config_values_are_retained_after_pod_deleted_and_restarted(ops_test):
-    pod_name = f"{app_name}-0"
+    pod_name = f"{grafana_app_name}-0"
 
     cmd = [
         "sg",
@@ -51,8 +101,21 @@ async def test_config_values_are_retained_after_pod_deleted_and_restarted(ops_te
     logger.debug(stdout)
 
     await ops_test.model.wait_for_idle(
-        apps=[app_name], status="active", wait_for_units=1, timeout=1000
+        apps=[grafana_app_name], status="active", wait_for_units=1, timeout=1000
     )
 
-    await check_grafana_is_ready(ops_test, app_name, 0)
-    assert (await get_config_values(ops_test, app_name)).items() >= config.items()
+    await check_grafana_is_ready(ops_test, grafana_app_name, 0)
+    assert (await get_config_values(ops_test, grafana_app_name)).items() >= config.items()
+
+
+async def test_dashboards_and_datasources_are_retained_after_pod_deleted_and_restarted(ops_test):
+    await check_grafana_is_ready(ops_test, grafana_app_name, 0)
+    tester_dashboard = await get_dashboard_by_search(
+        ops_test, grafana_app_name, 0, "Grafana Tester"
+    )
+    assert tester_dashboard != {}
+
+    datasource_suffix = "{}_0".format(tester_app_name)
+    datasources_with_relation = await get_grafana_datasources(ops_test, grafana_app_name, 0)
+    tester_datasource = get_datasource_for(datasource_suffix, datasources_with_relation)
+    assert tester_datasource != {}


### PR DESCRIPTION
## Issue
If a node is rebooted after relations are established, no relation events are fired which will cause data to be reprovisioned.

Closes #104 

## Solution
On `pebble_ready`, try to load any if we can get them from relations, since then we are reasonably sure that Grafana is up/available.


## Testing Instructions
Kubectl delete integration test updated to match

## Release Notes
Keep dashboards and datasources after deletion/reboot