### PR TITLE
add landing page integration

### DIFF
--- a/lib/charms/landing_page_k8s/v0/landing_page.py
+++ b/lib/charms/landing_page_k8s/v0/landing_page.py
@@ -1,0 +1,142 @@
+"""Charm for providing landing pages to bundles."""
+
+import ipaddress
+import socket
+from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.charm import CharmBase
+
+import logging
+
+LIBID = "7e5cd3b1e1264c2689f09f772c9af026"
+LIBAPI = 0
+LIBPATCH = 2
+
+DEFAULT_RELATION_NAME = "landing-page"
+
+logger = logging.getLogger(__name__)
+
+class LandingPageApp:
+    name: str
+    url: str
+    icon: str
+    description: str
+
+    def __init__(self, name, url, icon, description = ""):
+        self.name = name
+        self.url = url
+        self.icon = icon
+        self.description = description
+
+class LandingPageConsumer(Object):
+
+    def __init__(
+        self, 
+        charm,
+        relation_name: str = DEFAULT_RELATION_NAME, 
+        app: LandingPageApp = None
+    ):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._app = app
+
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_joined, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_changed)
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_relation_changed)
+        self.framework.observe(events.relation_created, self._on_relation_changed)
+
+
+
+    def _on_relation_changed(self, event):
+        if not self._charm.unit.is_leader():
+            return
+        
+        if not self._app:
+            return
+        
+        for relation in self._charm.model.relations[self._relation_name]:
+            relation.data[self._charm.model.app]["name"] = self._app.name
+            relation.data[self._charm.model.app]["description"] = self._app.description
+            relation.data[self._charm.model.app]["url"] = self.unit_address(relation)
+            relation.data[self._charm.model.app]["icon"] = self._app.icon
+
+    def unit_address(self, relation):
+        if self._app and self._app.url:
+            return self._app.url
+        
+        unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
+        if self._is_valid_unit_address(unit_ip):
+            return unit_ip
+        
+        return socket.getfqdn()
+
+    def _is_valid_unit_address(self, address: str) -> bool:
+        """Validate a unit address.
+        At present only IP address validation is supported, but
+        this may be extended to DNS addresses also, as needed.
+        Args:
+            address: a string representing a unit address
+        """
+        try:
+            _ = ipaddress.ip_address(address)
+        except ValueError:
+            return False
+
+        return True
+
+class AppsChangedEvent(EventBase):
+    """Event emitted when landing page app entries change."""
+
+    def __init__(self, handle, apps):
+        super().__init__(handle)
+        self.apps  = apps
+
+    def snapshot(self):
+        """Save landing page apps information."""
+        return {"apps": self.apps}
+
+    def restore(self, snapshot):
+        """Restore landing page apps information."""
+        self.apps = snapshot["apps"]
+
+
+class LandingPageEvents(ObjectEvents):
+    """Events raised by `LandingPageConsumer`"""
+
+    apps_changed = EventSource(AppsChangedEvent)
+
+class LandingPageProvider(Object):
+
+    on = LandingPageEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_changed, self._on_relation_changed)
+        self.framework.observe(events.relation_joined, self._on_relation_changed)
+        self.framework.observe(events.relation_departed, self._on_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_relation_broken)
+
+    def _on_relation_broken(self, event):
+        self.on.apps_changed.emit(apps=self.apps)
+
+    def _on_relation_changed(self, event):
+        
+        self.on.apps_changed.emit(apps=self.apps)
+
+    @property
+    def apps(self):
+        return [
+            {
+                "name": relation.data[relation.app].get("name", ""),
+                "url": relation.data[relation.app].get("url", ""),
+                "icon": relation.data[relation.app].get("icon", ""), 
+                "description": relation.data[relation.app].get("description", "")
+            }
+            for relation in self._charm.model.relations[self._relation_name]
+            if relation.app and relation.units
+        ]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,6 +30,7 @@ containers:
 storage:
   database:
     type: filesystem
+
 requires:
   grafana-source:
     interface: grafana_datasource
@@ -40,15 +41,20 @@ requires:
   database:
     interface: db
     limit: 1
+  landing-page:
+    interface: catalog
+
 provides:
   metrics-endpoint:
     interface: prometheus_scrape
   ingress:
     interface: traefik_route
     limit: 1
+
 peers:
   grafana:
     interface: grafana_peers
+
 resources:
   grafana-image:
     type: oci-image

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,10 +33,6 @@ from typing import Any, Callable, Dict
 from urllib.parse import ParseResult, urlparse
 
 import yaml
-from charms.landing_page_k8s.v0.landing_page import (
-    LandingPageConsumer,
-    LandingPageApp,
-)
 from charms.grafana_auth.v0.grafana_auth import AuthRequirer, AuthRequirerCharmEvents
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardConsumer
 from charms.grafana_k8s.v0.grafana_source import (
@@ -44,6 +40,7 @@ from charms.grafana_k8s.v0.grafana_source import (
     GrafanaSourceEvents,
     SourceFieldsMissingError,
 )
+from charms.landing_page_k8s.v0.landing_page import LandingPageApp, LandingPageConsumer
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     K8sResourcePatchFailedEvent,
     KubernetesComputeResourcesPatch,
@@ -126,9 +123,7 @@ class GrafanaCharm(CharmBase):
 
         self.metrics_endpoint = MetricsEndpointProvider(
             charm=self,
-            jobs=[{
-                "static_configs": [{"targets": ["*:3000"]}]
-            }],
+            jobs=[{"static_configs": [{"targets": ["*:3000"]}]}],
             refresh_event=self.on.grafana_pebble_ready,
         )
 
@@ -212,8 +207,8 @@ class GrafanaCharm(CharmBase):
                     "Grafana allows you to query, visualize, alert on, and "
                     "visualize metrics from mixed datasources in configurable "
                     "dashboards for observability."
-                )
-            )
+                ),
+            ),
         )
 
     def _on_install(self, _):


### PR DESCRIPTION
This PR introduces a new relation interface called `catalog` for connecting Grafana to a landing page. Over this relation, Grafana provides an application entry, which then will be used by the landing page to display where users may go.

## Context
See https://github.com/canonical/landing-page-k8s-operator/ for the other end of this relation.

## Testing Instructions
- Build a charm file from this PR branch
- Deploy the build output on Juju
- Deploy `landing-page-k8s` from `edge`
- Relate the two charms together
- Visit the landing page on port 80

## Release Notes
Implement the `catalog` interface to allow for integration with `landing-page-k8s`.