### PR TITLE
Add a pebble guard at the beginning of _configure_replication

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -273,7 +273,7 @@ class GrafanaCharm(CharmBase):
         Args:
             leader: a boolean indicating the leader status
         """
-        if not self.containers["replicaton"].can_connect():
+        if not self.containers["replication"].can_connect():
             return
 
         restart = False

--- a/src/charm.py
+++ b/src/charm.py
@@ -273,6 +273,9 @@ class GrafanaCharm(CharmBase):
         Args:
             leader: a boolean indicating the leader status
         """
+        if not self.containers["replicaton"].can_connect():
+            return
+
         restart = False
         leader = self.unit.is_leader()
 


### PR DESCRIPTION
## Issue
Add a guard around connection to the litestream container. This was not previously observed, but is reproducible when deploying from a bundle or another scenario which sets config values before the workload is ready.

Closes #130 

## Solution
Add another `can_connect()` guard.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
Guard in `_configure_replication()`