### PR TITLE
Inject loki datasource variable dropdowns also

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -218,7 +218,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 logger = logging.getLogger(__name__)
 
@@ -341,6 +341,21 @@ DATASOURCE_TEMPLATE_DROPDOWNS = [  # type: ignore
         "name": "prometheusds",
         "options": [],
         "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": False,
+        "type": "datasource",
+    },
+    {
+        "description": None,
+        "error": None,
+        "hide": 0,
+        "includeAll": False,
+        "label": None,
+        "multi": False,
+        "name": "lokids",
+        "options": [],
+        "query": "loki",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": False,


### PR DESCRIPTION
## Issue
We already inject a dropdown for Prometheus datasources. Add one for Loki also.

## Solution
Add a dropdown selector for the `${lokids}` variable, and an additional unit test to verify that we don't clobber it if it already exists.

## Testing Instructions
Deploy and ensure the dropdown is present, and can resolve to a related loki.

## Release Notes
Inject loki datasource variable dropdowns also