### PR TITLE
Add a fallthrough in _configure in case of node reboot with persistent configurations

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -405,6 +405,15 @@ class GrafanaCharm(CharmBase):
 
         if restart:
             self.restart_grafana()
+        else:
+            # All clear, move to active.
+            # We can basically only get here if the charm is completely restarted, but all of
+            # the configs are correct, with the correct pebble plan, such as a node reboot.
+            #
+            # A node reboot does not send any identifiable events (`start`, `pebble_ready`), so
+            # this is more or less the 'fallthrough' part of a case statement
+            if not isinstance(self.unit.status, ActiveStatus):
+                self.unit.status = ActiveStatus()
 
     def _update_datasource_config(self, config: str) -> None:
         """Write an updated datasource configuration file to the Pebble container if necessary.


### PR DESCRIPTION

## Issue
In case of a node reboot in some cases (charmed k8s on vsphere with integrations, for example), it's possible for a node reboot to result in a charm restart which fires `start` and `pebble_ready`, but `_configure` still finds all values unchanged (pebble plans are correct, the hashes of on-disk configuration files are still what we expect, k8s service patch is applied), and the charm never moves to `restart_grafana`, which is where `ActiveStatus` is set (since, in normal operation, a start, upgrade, pod kill, datasource relation change, layer change, leader change for replication, and all other scenarios would result in `restart = True`).

## Solution
If we hit the end of `_configure`, and `restart = False`, make sure the charm is in `ActiveStatus`.

## Context
Closes #133, with context in that issue.

## Release Notes
Add a fallthrough in _configure in case of node reboot with persistent configurations