### PR TITLE
Rename self-monitoring dashboard

### DIFF
--- a/src/self_dashboard.json
+++ b/src/self_dashboard.json
@@ -1062,7 +1062,7 @@
     ]
   },
   "timezone": "",
-  "title": "Grafana Self Monitoring Metrics",
+  "title": "Grafana Operator Overview",
   "uid": "isFoa0z7k",
   "version": 1
 }


### PR DESCRIPTION
## Issue
Name of the dashboard differs from the naming convention used for Prometheus (and soon, Loki).

## Solution
Rename dashboard to "Grafana Operator Overview".


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
N/A

## Release Notes
<!-- A digestable summary of the change in this PR -->
Rename the Grafana self-monitoring dashboard