### PR TITLE
Use cos-tool to template with Grafana variables instead of 'raw' topology

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -218,7 +218,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 logger = logging.getLogger(__name__)
 
@@ -565,7 +565,7 @@ def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> st
     existing_templates = False
 
     template_dropdowns = (
-        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS  # type: ignore
+        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS
         if inject_dropdowns
         else DATASOURCE_TEMPLATE_DROPDOWNS
     )
@@ -1870,8 +1870,13 @@ class CosTool:
             logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
             return expression
         args = [str(self.path), "--format", type, "transform"]
+
+        variable_topology = {k: "${}".format(k) for k in topology.keys()}
         args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
+            [
+                "--label-matcher={}={}".format(key, value)
+                for key, value in variable_topology.items()
+            ]
         )
 
         # Pass a leading "--" so expressions with a negation or subtraction aren't interpreted as

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -565,7 +565,7 @@ def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> st
     existing_templates = False
 
     template_dropdowns = (
-        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS
+        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS  # type: ignore
         if inject_dropdowns
         else DATASOURCE_TEMPLATE_DROPDOWNS
     )

--- a/tests/unit/test_dashboard_transform.py
+++ b/tests/unit/test_dashboard_transform.py
@@ -288,7 +288,6 @@ class ConsumerCharm(CharmBase):
 @patch.object(base64, "b64decode", new=lambda x: x)
 class TestDashboardLabelInjector(unittest.TestCase):
     def setUp(self):
-        self.maxDiff = None
         meta = open("metadata.yaml")
         self.harness = Harness(ConsumerCharm, meta=meta)
         self.harness.set_model_info(name=MODEL_INFO["name"], uuid=MODEL_INFO["uuid"])

--- a/tests/unit/test_dashboard_transform.py
+++ b/tests/unit/test_dashboard_transform.py
@@ -60,7 +60,7 @@ DASHBOARD_RENDERED = json.dumps(
                 "datasource": "${prometheusds}",
                 "targets": [
                     {
-                        "expr": 'up{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"}',
+                        "expr": 'up{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"}',
                     },
                 ],
             },
@@ -104,7 +104,7 @@ LOKI_DASHBOARD_RENDERED = json.dumps(
                 "datasource": "${lokids}",
                 "targets": [
                     {
-                        "expr": r'{job=".+", juju_application="provider-tester", juju_model="testing", juju_model_uuid="abcdefgh-1234", juju_unit="provider-tester/0"}',
+                        "expr": r'{job=".+", juju_application="$juju_application", juju_model="$juju_model", juju_model_uuid="$juju_model_uuid", juju_unit="$juju_unit"}',
                     },
                 ],
             },
@@ -155,10 +155,10 @@ DASHBOARD_RENDERED_WITH_NEGATIVE = json.dumps(
                 "data": "label_values(up, juju_unit)",
                 "targets": [
                     {
-                        "expr": 'sum(up{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"})',
+                        "expr": 'sum(up{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"})',
                     },
                     {
-                        "expr": '-sum(up{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"})',
+                        "expr": '-sum(up{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"})',
                     },
                 ],
                 "datasource": "${prometheusds}",
@@ -202,7 +202,7 @@ DASHBOARD_RENDERED_WITH_RANGES = json.dumps(
                 "data": "label_values(up, juju_unit)",
                 "targets": [
                     {
-                        "expr": 'rate(http_requests_total{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"}[$__interval]) / rate(http_requests_total{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"}[5m]) >= 0',
+                        "expr": 'rate(http_requests_total{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"}[$__interval]) / rate(http_requests_total{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"}[5m]) >= 0',
                     },
                 ],
                 "datasource": "${prometheusds}",
@@ -246,7 +246,7 @@ DASHBOARD_RENDERED_WITH_OFFSETS = json.dumps(
                 "data": "label_values(up, juju_unit)",
                 "targets": [
                     {
-                        "expr": 'sum(http_requests_total{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"} offset $__interval) - sum(http_requests_total{job="foo",juju_application="provider-tester",juju_model="testing",juju_model_uuid="abcdefgh-1234",juju_unit="provider-tester/0"} offset -5m)',
+                        "expr": 'sum(http_requests_total{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"} offset $__interval) - sum(http_requests_total{job="foo",juju_application="$juju_application",juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_unit="$juju_unit"} offset -5m)',
                     },
                 ],
                 "datasource": "${prometheusds}",
@@ -288,6 +288,7 @@ class ConsumerCharm(CharmBase):
 @patch.object(base64, "b64decode", new=lambda x: x)
 class TestDashboardLabelInjector(unittest.TestCase):
     def setUp(self):
+        self.maxDiff = None
         meta = open("metadata.yaml")
         self.harness = Harness(ConsumerCharm, meta=meta)
         self.harness.set_model_info(name=MODEL_INFO["name"], uuid=MODEL_INFO["uuid"])


### PR DESCRIPTION
## Issue
Currently, `cos-tool` via `grafana-dashboard` is injecting "actual"/"realized" topology into dashboard panels rather than template variables, which is undesirable.

## Solution
Remap the keys into variables before injection

## Release Notes
Use cos-tool to template with Grafana variables instead of 'raw' topology