### PR TITLE
Update to grafana 9.2.1, punch through external_host

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""## Overview.
+"""Source code can be found on GitHub at canonical/observability-libs/lib/charms/observability_libs.
+
+## Overview
 
 This document explains how to integrate with the Prometheus charm
 for the purpose of providing a metrics endpoint to Prometheus. It
@@ -10,6 +12,13 @@ currently integrated charms. Finally this document is the
 authoritative reference on the structure of relation data that is
 shared between Prometheus charms and any other charm that intends to
 provide a scrape target for Prometheus.
+
+## Dependencies
+
+Using this library requires you to fetch the juju_topology library from
+[observability-libs](https://charmhub.io/observability-libs/libraries/juju_topology).
+
+`charmcraft fetch-lib charms.observability_libs.v0.juju_topology`
 
 ## Provider Library Usage
 
@@ -341,7 +350,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 logger = logging.getLogger(__name__)
 
@@ -1516,10 +1525,11 @@ class MetricsEndpointProvider(Object):
         self.external_url = external_url
 
         events = self._charm.on[self._relation_name]
-        self.framework.observe(events.relation_joined, self._set_scrape_job_spec)
         self.framework.observe(events.relation_changed, self._on_relation_changed)
 
         if not refresh_event:
+            # FIXME remove once podspec charms are verified.
+            # `self._set_scrape_job_spec()` is called every re-init so this should not be needed.
             if len(self._charm.meta.containers) == 1:
                 if "kubernetes" in self._charm.meta.series:
                     # This is a podspec charm
@@ -1544,10 +1554,16 @@ class MetricsEndpointProvider(Object):
         for ev in refresh_event:
             self.framework.observe(ev, self._set_scrape_job_spec)
 
-        self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
-
-        # If there is no leader during relation_joined we will still need to set alert rules.
-        self.framework.observe(self._charm.on.leader_elected, self._set_scrape_job_spec)
+        # Update relation data every reinit. If instead we used event hooks then observing only
+        # relation-joined would not be sufficient:
+        # - Would need to observe leader-elected, in case there was no leader during
+        #   relation-joined.
+        # - If later related to an ingress provider, then would need to register and wait for
+        #   update-status interval to elapse before changes would apply.
+        # - The ingerss-ready custom event is currently emitted prematurely and cannot be relied
+        #   upon: https://github.com/canonical/traefik-k8s-operator/issues/78
+        # NOTE We may still end up waiting for update-status before changes are applied.
+        self._set_scrape_job_spec()
 
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""
@@ -1563,9 +1579,7 @@ class MetricsEndpointProvider(Object):
                 else:
                     self.on.alert_rule_status_changed.emit(valid=valid, errors=errors)
 
-        self._set_scrape_job_spec(event)
-
-    def _set_scrape_job_spec(self, event):
+    def _set_scrape_job_spec(self, _=None):
         """Ensure scrape target information is made available to prometheus.
 
         When a metrics provider charm is related to a prometheus charm, the
@@ -1574,7 +1588,7 @@ class MetricsEndpointProvider(Object):
         data. In addition, each of the consumer units also sets its own
         host address in Juju unit relation data.
         """
-        self._set_unit_ip(event)
+        self._set_unit_ip()
 
         if not self._charm.unit.is_leader():
             return
@@ -1594,7 +1608,7 @@ class MetricsEndpointProvider(Object):
                 # that is written to the filesystem.
                 relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
-    def _set_unit_ip(self, _):
+    def _set_unit_ip(self, _=None):
         """Set unit host address.
 
         Each time a metrics provider charm container is restarted it updates its own

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -59,7 +59,7 @@ resources:
   grafana-image:
     type: oci-image
     description: upstream docker image for Grafana
-    upstream-source: docker.io/ubuntu/grafana:8.2-22.04_beta
+    upstream-source: docker.io/ubuntu/grafana:9.2-22.04_beta
   litestream-image:
     type: oci-image
     description: upstream image for sqlite streaming

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,6 +202,7 @@ class GrafanaCharm(CharmBase):
             refresh_event=[
                 self.on.grafana_pebble_ready,
                 self.on["ingress"].relation_joined,
+                self.on["ingress"].relation_changed,
             ],
             item=CatalogueItem(
                 name="Grafana",
@@ -1059,21 +1060,16 @@ class GrafanaCharm(CharmBase):
     @property
     def external_url(self) -> str:
         """Return the external hostname configured, if any."""
-        baseurl = ""
-        if self.ingress.external_host:
-            baseurl = "http://{}".format(self.ingress.external_host)
-        else:
-            baseurl = "http://{}:{}".format(socket.getfqdn(), PORT)
-
         web_external_url = self.model.config.get("web_external_url", "")
-
         if web_external_url:
             return web_external_url
 
-        if self.ingress.is_ready():
+        baseurl = ""
+        if self.ingress.external_host:
+            baseurl = "http://{}".format(self.ingress.external_host)
             return "{}/{}".format(baseurl, "{}-{}".format(self.model.name, self.model.app.name))
-
-        return baseurl
+        else:
+            return "http://{}:{}".format(socket.getfqdn(), PORT)
 
     @property
     def _ingress_config(self) -> dict:


### PR DESCRIPTION
## Issue
Update to Grafana 9.2.1. Ensure that `external_host` updates are always passed from `TraefikRoute`


## Release Notes
Update to Grafana 9.2.1. Ensure that `external_host` updates are always passed from `TraefikRoute`
