### PR TITLE
Remove a leftover debugging log statement

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -218,7 +218,6 @@ class TraefikRouteRequirer(Object):
     def external_host(self) -> str:
         """Return the external host set by Traefik, if any."""
         self._update_stored_external_host()
-        log.warning("---- EXTERNAL_HOST IS: {}".format(self._stored.external_host))
         return self._stored.external_host or ""
 
     def _update_stored_external_host(self) -> None:


### PR DESCRIPTION
## Issue
Kill a leftover `logger.warning` from testing

## Release Notes
Remove a leftover debugging log statement