### PR TITLE
Fix: Adjust grafana minimum resource requirements to match official values

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1051,7 +1051,7 @@ class GrafanaCharm(CharmBase):
 
     def _resource_reqs_from_config(self) -> ResourceRequirements:
         limits = {"cpu": self.model.config.get("cpu"), "memory": self.model.config.get("memory")}
-        requests = {"cpu": "0.25", "memory": "200Mi"}
+        requests = {"cpu": "1", "memory": "260Mi"}
         return adjust_resource_requirements(limits, requests, adhere_to_requests=True)
 
     def _on_resource_patch_failed(self, event: K8sResourcePatchFailedEvent):


### PR DESCRIPTION

## Issue
During testing by the Solutions QA team, we found that the charm was requesting too little CPU and memory from Kubernetes, most likely leading to Grafana failing to start.


## Solution
Adjusting the requested resources to the minimum values specified in the official Grafana [hardware requirements](https://grafana.com/docs/grafana/latest/setup-grafana/installation/#hardware-recommendations) page.


## Context
We use grafana as part of our COS layer, this time running on a Jammy Kubernetes Baremetal configuration. Logs will be attached to this MR as a subsequent comment.


## Testing Instructions
Deploy as usual and verify the requested resources changed to the new values.


## Release Notes
- Changes requested CPU amount from `0.25` to `1`.
- Changes requested memory amount from `200Mi` to `260Mi`
