### PR TITLE
Make sure racy external_host returns from Traefik still set SERVE_FROM_SUB_PATH

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,21 +1,22 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: grafana-k8s
-display-name: Grafana
+assumes:
+  - k8s-api
 summary: Data visualization and observability with Grafana
+
+website: https://charmhub.io/grafana-k8s
+source: https://github.com/canonical/grafana-k8s-operator
+issues: https://github.com/canonical/alertmanager-k8s-operator/issues
 docs: https://discourse.charmhub.io/t/grafana-operator-k8s-docs-index/5612
+
 maintainers:
   - Ryan Barry <ryan.barry@canonical.com>
 description: |
   Grafana provides dashboards for monitoring data and this
   charm is written to allow for HA on Kubernetes and can take
   multiple data sources (for example, Prometheus).
-tags:
-  - observability
-  - lma
-  - monitoring
-  - grafana
-  - prometheus
+
 containers:
   grafana:
     resource: grafana-image

--- a/src/charm.py
+++ b/src/charm.py
@@ -275,9 +275,6 @@ class GrafanaCharm(CharmBase):
         If a leader election event through `config-changed` would result in a new primary, start
         it. If the address provided by the leader in peer data changes, `leader` will be false,
         and replicas will be started.
-
-        Args:
-            leader: a boolean indicating the leader status
         """
         if not self.containers["replication"].can_connect():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -333,12 +333,11 @@ class GrafanaCharm(CharmBase):
         dashboards_dir_path = os.path.join(PROVISIONING_PATH, "dashboards")
         self.init_dashboard_provisioning(dashboards_dir_path)
 
-        dashboard_path = os.path.join(dashboards_dir_path, "grafana_metrics.json")
+        dashboard_path = os.path.join(dashboards_dir_path, "self_dashboard.json")
         if has_relation and self.unit.is_leader():
             # This is not going through the library due to the massive refactor needed in order
             # to squash all of the `validate_relation_direction` and structure around smashing
-            # the datastructures for a self-monitoring use case. This is built-in in Grafana 9,
-            # so it will FIXME be removed when we upgrade
+            # the datastructures for a self-monitoring use case.
             container.push(
                 dashboard_path, Path("src/self_dashboard.json").read_bytes(), make_dirs=True
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -342,7 +342,7 @@ class GrafanaCharm(CharmBase):
                 dashboard_path, Path("src/self_dashboard.json").read_bytes(), make_dirs=True
             )
         elif not has_relation or isinstance(event, RelationBrokenEvent):
-            if container.list_files(dashboards_dir_path, pattern="grafana_metrics.json"):
+            if container.list_files(dashboards_dir_path, pattern="self_dashboard.json"):
                 container.remove_path(dashboard_path)
                 logger.debug("Removed dashboard %s", dashboard_path)
                 self.restart_grafana()

--- a/src/charm.py
+++ b/src/charm.py
@@ -1083,9 +1083,15 @@ class GrafanaCharm(CharmBase):
         pattern = r"^{}\..*?{}\.".format(self.model.unit.name.replace("/", "-"), self.model.name)
         domain = re.split(pattern, fqdn)[1]
 
-        external_path = urlparse(self.external_url).path or "{}-{}".format(
-            self.model.name, self.model.app.name
-        )
+        if self.external_url == self.ingress.external_host:
+            external_path = "{}-{}".format(self.model.name, self.model.app.name)
+        else:
+            external_path = urlparse(self.external_url).path or "{}-{}".format(
+                self.model.name, self.model.app.name
+            )
+
+        if not external_path.startswith("/"):
+            external_path = "/{}".format(external_path)
 
         routers = {
             "juju-{}-{}-router".format(self.model.name, self.model.app.name): {

--- a/src/charm.py
+++ b/src/charm.py
@@ -194,6 +194,7 @@ class GrafanaCharm(CharmBase):
         # so this may be none. Rely on `self.ingress.is_ready` later to check
         self.ingress = TraefikRouteRequirer(self, self.model.get_relation("ingress"), "ingress")  # type: ignore
         self.framework.observe(self.on["ingress"].relation_joined, self._configure_ingress)
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         self.framework.observe(self.on.leader_elected, self._configure_ingress)
         self.framework.observe(self.on.config_changed, self._configure_ingress)
 
@@ -233,6 +234,10 @@ class GrafanaCharm(CharmBase):
         """
         self._configure()
         self._configure_replication()
+
+    def _on_ingress_ready(self, _) -> None:
+        """Once Traefik tells us our external URL, make sure we reconfigure Grafana."""
+        self._configure()
 
     def _configure_ingress(self, event: HookEvent) -> None:
         """Set up ingress if a relation is joined, config changed, or a new leader election.

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -5,7 +5,6 @@
 import asyncio
 import logging
 
-import aiohttp
 import pytest
 from helpers import ModelConfigChange, grafana_password, oci_image, reenable_metallb
 from pytest_operator.plugin import OpsTest
@@ -75,15 +74,6 @@ async def test_grafana_is_reachable_via_traefik(ops_test: OpsTest):
     # THEN the grafana API is served on metallb's IP
     pw = await grafana_password(ops_test, grafana_app_name)
     grafana = Grafana(host=ip, path=f"{ops_test.model_name}-{grafana_app_name}", port=80, pw=pw)
-
-    # Temporary workaround
-    for _ in range(3):
-        try:
-            # is_ready raises when ingress is not yet ready and the response is not json (plain string 404 error)
-            await grafana.is_ready()
-            break
-        except aiohttp.client_exceptions.ContentTypeError:
-            await asyncio.sleep(30)
 
     is_ready = await grafana.is_ready()
     assert is_ready

--- a/tests/integration/test_external_url.py
+++ b/tests/integration/test_external_url.py
@@ -5,6 +5,7 @@
 import asyncio
 import logging
 
+import aiohttp
 import pytest
 from helpers import ModelConfigChange, grafana_password, oci_image, reenable_metallb
 from pytest_operator.plugin import OpsTest
@@ -74,5 +75,15 @@ async def test_grafana_is_reachable_via_traefik(ops_test: OpsTest):
     # THEN the grafana API is served on metallb's IP
     pw = await grafana_password(ops_test, grafana_app_name)
     grafana = Grafana(host=ip, path=f"{ops_test.model_name}-{grafana_app_name}", port=80, pw=pw)
+
+    # Temporary workaround
+    for _ in range(3):
+        try:
+            # is_ready raises when ingress is not yet ready and the response is not json (plain string 404 error)
+            await grafana.is_ready()
+            break
+        except aiohttp.client_exceptions.ContentTypeError:
+            await asyncio.sleep(30)
+
     is_ready = await grafana.is_ready()
     assert is_ready

--- a/tests/integration/test_selfmonitoring_dashboard.py
+++ b/tests/integration/test_selfmonitoring_dashboard.py
@@ -72,12 +72,10 @@ async def test_grafana_self_monitoring_dashboard_is_present(ops_test):
         ),
     )
     await ops_test.model.wait_for_idle(
-        apps=[grafana_app_name, prometheus_app_name], status="active", idle_period=30
+        apps=[grafana_app_name, prometheus_app_name], status="active", idle_period=60
     )
 
-    self_dashboard = await get_dashboard_by_search(
-        ops_test, grafana_app_name, 0, "Grafana Operator Overview"
-    )
+    self_dashboard = await get_dashboard_by_search(ops_test, grafana_app_name, 0, "Grafana")
     assert self_dashboard != {}
 
 

--- a/tests/integration/test_selfmonitoring_dashboard.py
+++ b/tests/integration/test_selfmonitoring_dashboard.py
@@ -76,7 +76,7 @@ async def test_grafana_self_monitoring_dashboard_is_present(ops_test):
     )
 
     self_dashboard = await get_dashboard_by_search(
-        ops_test, grafana_app_name, 0, "Grafana Self Monitoring"
+        ops_test, grafana_app_name, 0, "Grafana Operator Overview"
     )
     assert self_dashboard != {}
 
@@ -94,5 +94,5 @@ async def test_remove(ops_test):
         apps=[grafana_app_name], status="active", timeout=300, idle_period=60
     )
 
-    # relation_removed_dashboards = await get_grafana_dashboards(ops_test, grafana_app_name, 0)
-    # assert relation_removed_dashboards == []
+    relation_removed_dashboards = await get_grafana_dashboards(ops_test, grafana_app_name, 0)
+    assert relation_removed_dashboards == []

--- a/tests/integration/test_selfmonitoring_dashboard.py
+++ b/tests/integration/test_selfmonitoring_dashboard.py
@@ -37,9 +37,14 @@ async def test_deploy(ops_test, grafana_charm):
             resources=grafana_resources,
             application_name=grafana_app_name,
             trust=True,
+            series="focal",
         ),
         ops_test.model.deploy(
-            "prometheus-k8s", channel="edge", trust=True, application_name=prometheus_app_name
+            "prometheus-k8s",
+            channel="edge",
+            trust=True,
+            application_name=prometheus_app_name,
+            series="focal",
         ),
     )
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_selfmonitoring_dashboard.py
+++ b/tests/integration/test_selfmonitoring_dashboard.py
@@ -45,7 +45,6 @@ async def test_deploy(ops_test, grafana_charm):
     await ops_test.model.wait_for_idle(
         apps=[grafana_app_name, prometheus_app_name],
         status="active",
-        wait_for_units=1,
         timeout=300,
     )
 

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import unittest
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import ops
+from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
+from ops.model import ActiveStatus
+from ops.testing import Harness
+
+from charm import PORT, GrafanaCharm
+
+logger = logging.getLogger(__name__)
+
+ops.testing.SIMULATE_CAN_CONNECT = True
+CONTAINER_NAME = "grafana"
+SERVICE_NAME = "grafana"
+
+k8s_resource_multipatch = patch.multiple(
+    "charm.KubernetesComputeResourcesPatch",
+    _namespace="test-namespace",
+    _patch=lambda *a, **kw: True,
+    is_ready=lambda *a, **kw: True,
+)
+
+
+class TestExternalUrl(unittest.TestCase):
+    """External url sources have a precedence, and must be correctly propagated everywhere."""
+
+    def setUp(self, *unused):
+        self.harness = Harness(GrafanaCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        model_name = "testmodel"
+        self.harness.set_model_name(model_name)
+        for p in [
+            patch("charm.K8sServicePatch"),
+            patch("lightkube.core.client.GenericSyncClient"),
+            patch(
+                "socket.getfqdn", new=lambda *args: f"grafana-k8s-0.{model_name}.svc.cluster.local"
+            ),
+            patch("socket.gethostbyname", new=lambda *args: "1.2.3.4"),
+            k8s_resource_multipatch,
+            patch.object(GrafanaCharm, "grafana_version", "0.0.0"),
+            patch("ops.testing._TestingModelBackend.network_get"),
+            patch("ops.testing._TestingPebbleClient.exec", MagicMock()),
+        ]:
+            p.start()
+            self.addCleanup(p.stop)
+
+        self.harness.set_leader(True)
+
+        # Peer relation
+        self.app_name = "grafana-k8s"
+        self.peer_rel_id = self.harness.add_relation("grafana", self.app_name)
+
+        # Auth relation
+        # FIXME why tests fail when this relation is not created?
+        self.grafana_auth_rel_id = self.harness.add_relation("grafana-auth", "auth_provider")
+
+        self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready(CONTAINER_NAME)
+        self.harness.container_pebble_ready("litestream")
+        self.fqdn_url = f"http://fqdn:{PORT}"
+
+    def get_pebble_env(self) -> Dict[str, str]:
+        service = (
+            self.harness.get_container_pebble_plan(CONTAINER_NAME).services["grafana"].to_dict()
+        )
+        return service["environment"]
+
+    def is_service_running(self) -> bool:
+        service = self.harness.model.unit.get_container(CONTAINER_NAME).get_service(SERVICE_NAME)
+        return service.is_running()
+
+    @patch.object(TraefikRouteRequirer, "external_host", new="1.2.3.4")
+    def test_url_without_path(self):
+        """The root url and subpath env vars should not be set when no subpath is present."""
+        # GIVEN a charm with an fqdn as its external URL
+        # (this is set by a mock decorator)
+
+        # THEN root url and subpath envs are not defined (redirect to login is fine with a bare hostname)
+        self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
+        self.assertNotIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
+        self.assertTrue(self.is_service_running())
+
+    def test_external_url_precedence(self):
+        """Precedence is [config option] > [ingress] > [fqdn]."""
+        # GIVEN a charm with the fqdn as its external URL
+        # (this is set by a mock decorator)
+
+        # WHEN a relation with traefik is formed
+        with patch.object(TraefikRouteRequirer, "external_host", new="1.2.3.4"):
+            rel_id = self.harness.add_relation("ingress", "traefik-app")
+            self.harness.add_relation_unit(rel_id, "traefik-app/0")
+
+            # AND ingress becomes ready
+            self.harness.charm.ingress.on.ready.emit(
+                self.harness.charm.model.get_relation("ingress", rel_id)
+            )
+
+            # THEN root url and subpath envs are defined
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
+            self.assertEqual(
+                self.get_pebble_env()["GF_SERVER_ROOT_URL"],
+                "http://0.0.0.0:3000/testmodel-grafana-k8s",
+            )
+            self.assertTrue(self.is_service_running())
+
+            # WHEN the web_external_url config option is set
+            external_url_config = "http://foo.bar.config:8080/path/to/grafana"
+            self.harness.update_config({"web_external_url": external_url_config})
+
+            # THEN root url is updated (config option has higher precedence than ingress)
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
+            self.assertEqual(
+                self.get_pebble_env()["GF_SERVER_ROOT_URL"], "http://0.0.0.0:8080/path/to/grafana"
+            )
+            self.assertTrue(self.is_service_running())
+
+            # WHEN the web_external_url config option is cleared
+            self.harness.update_config(unset=["web_external_url"])
+
+            # THEN root url is reverted to the one coming from ingress
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
+            self.assertEqual(
+                self.get_pebble_env()["GF_SERVER_ROOT_URL"],
+                "http://0.0.0.0:3000/testmodel-grafana-k8s",
+            )
+
+        # WHEN the traefik relation is removed
+        with patch.object(TraefikRouteRequirer, "external_host", new=""):
+            self.harness.remove_relation_unit(rel_id, "traefik-app/0")
+            self.harness.remove_relation(rel_id)
+
+            # THEN root url and subpath envs are undefined again (because fqdn is a bare hostname)
+            self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
+            self.assertNotIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
+            self.assertTrue(self.is_service_running())
+
+    @unittest.skip("The admin intentionally sets this. Leaving it not fully specced for now.")
+    def test_invalid_web_route_prefix(self):
+        for invalid_url in ["htp:/foo.bar", "htp://foo.bar", "foo.bar"]:
+            with self.subTest(url=invalid_url):
+                # WHEN the external url config option is invalid
+                self.harness.update_config({"web_external_url": invalid_url})
+
+                # THEN the unit is active
+                # TODO change to blocked
+                self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+                # AND the pebble envvars are set, even though values are invalid
+                self.assertIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
+                self.assertIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
+                self.assertTrue(self.is_service_running())
+
+                # WHEN the invalid option in cleared
+                self.harness.update_config(unset=["web_external_url"])
+
+                # THEN the unit is active
+                self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)


### PR DESCRIPTION
## Issue
On CPU-constrained systems, reconfiguration of Grafana may happen before `external_host` resolves the route from Traefik, leaving to a layer config which does not include `SERVE_FROM_SUBPATH`, and requests redirect to `http://uri/login` (for example)

## Solution
Catch `ingress.on.ready` and ensure the Grafana layer has the correct configuration


## Release Notes
Make sure racy external_host returns from Traefik still set SERVE_FROM_SUB_PATH