### PR TITLE
More refresh events for catalogue

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -203,7 +203,10 @@ class GrafanaCharm(CharmBase):
             refresh_event=[
                 self.on.grafana_pebble_ready,
                 self.ingress.on.ready,
-                self.ingress.on.revoked,
+                # TODO use revoked instead of relation events when it becomes available
+                # https://github.com/canonical/traefik-route-k8s-operator/issues/21
+                # self.ingress.on.revoked,
+                self.on["ingress"].relation_broken,
                 self.on.config_changed,  # web_external_url; also covers upgrade-charm
                 # TODO remove the following after the traefik issue is fixed
                 #  https://github.com/canonical/traefik-k8s-operator/issues/78

--- a/src/charm.py
+++ b/src/charm.py
@@ -208,11 +208,6 @@ class GrafanaCharm(CharmBase):
                 # self.ingress.on.revoked,
                 self.on["ingress"].relation_broken,
                 self.on.config_changed,  # web_external_url; also covers upgrade-charm
-                # TODO remove the following after the traefik issue is fixed
-                #  https://github.com/canonical/traefik-k8s-operator/issues/78
-                self.on["ingress"].relation_joined,
-                self.on["ingress"].relation_changed,
-                self.on.update_status,
             ],
             item=CatalogueItem(
                 name="Grafana",

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,8 +202,14 @@ class GrafanaCharm(CharmBase):
             charm=self,
             refresh_event=[
                 self.on.grafana_pebble_ready,
+                self.ingress.on.ready,
+                self.ingress.on.revoked,
+                self.on.config_changed,  # web_external_url; also covers upgrade-charm
+                # TODO remove the following after the traefik issue is fixed
+                #  https://github.com/canonical/traefik-k8s-operator/issues/78
                 self.on["ingress"].relation_joined,
                 self.on["ingress"].relation_changed,
+                self.on.update_status,
             ],
             item=CatalogueItem(
                 name="Grafana",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -365,7 +365,7 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.containers["workload"].get_plan().services["grafana"].to_dict()
         )
         self.assertIn("GF_AUTH_PROXY_ENABLED", services["environment"].keys())
-        self.assertEquals(services["environment"]["GF_AUTH_PROXY_ENABLED"], "True")
+        self.assertEqual(services["environment"]["GF_AUTH_PROXY_ENABLED"], "True")
 
 
 class TestCharmReplication(unittest.TestCase):


### PR DESCRIPTION
## Issue
In a load test deployment, the link was still wrong.


## Solution
Add more refresh events.


## Context
Addresses https://github.com/canonical/catalogue-k8s-operator/issues/3.


## Testing Instructions
1. Deploy the cos-lite bundle.
2. Make sure grafana has the correct url.


## Release Notes
Add more refresh events for catalogue.
