### PR TITLE
Don't inject labels with cos-tool if dropdown injection is disabled

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -218,7 +218,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 logger = logging.getLogger(__name__)
 
@@ -1155,7 +1155,7 @@ class GrafanaDashboardProvider(Object):
         return {
             "charm": self._charm.meta.name,
             "content": content,
-            "juju_topology": self._juju_topology,
+            "juju_topology": self._juju_topology if inject_dropdowns else {},
             "inject_dropdowns": inject_dropdowns,
         }
 

--- a/tests/unit/test_dashboard_provider.py
+++ b/tests/unit/test_dashboard_provider.py
@@ -68,12 +68,7 @@ MANUAL_TEMPLATE_DATA_NO_DROPDOWNS = {
         "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQALdGVzdF9tYW51YWwKAJN3IemeHXT1AAEkDKYY2NgftvN9AQAAAAAEWVo=",
         "inject_dropdowns": False,
         "dashboard_alt_uid": "0b73d01f7b214e98",
-        "juju_topology": {
-            "application": "provider-tester",
-            "model": "testing",
-            "model_uuid": "abcdefgh-1234",
-            "unit": "provider-tester/0",
-        },
+        "juju_topology": {},
     }
 }
 


### PR DESCRIPTION
## Issue
When injection with `cos-tool` was added, even if `inject_dropdowns` is false (for "static" dashboards via `cos-config` or other), the addition of topology in the provided relation data will trigger injection via cos-tool

## Solution
If `inject_dropdowns` is `True`, also avoid passing along toplogy.

## Release Notes
Don't inject labels with cos-tool if dropdown injection is disabled