### PR TITLE
Dict datasources

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -632,7 +632,7 @@ def _replace_template_fields(  # noqa: C901
                     else:
                         panel["datasource"] = "${prometheusds}"
                 elif type(datasource) == dict:
-                # In dashboards exported by Grafana 9, datasource type is dict
+                    # In dashboards exported by Grafana 9, datasource type is dict
                     dstype = datasource.get("type", "")
                     if dstype == "loki":
                         panel["datasource"]["uid"] = "${lokids}"

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -622,7 +622,7 @@ def _replace_template_fields(  # noqa: C901
         #
         # COS only knows about Prometheus and Loki.
         for panel in panels:
-            if "datasource" not in panel or not panel.get("datasource", ""):
+            if "datasource" not in panel or not panel.get("datasource"):
                 continue
             if not existing_templates:
                 datasource = panel.get("datasource")
@@ -632,13 +632,14 @@ def _replace_template_fields(  # noqa: C901
                     else:
                         panel["datasource"] = "${prometheusds}"
                 elif type(datasource) == dict:
-                    dstype = datasource.get("type")
+                # In dashboards exported by Grafana 9, datasource type is dict
+                    dstype = datasource.get("type", "")
                     if dstype == "loki":
                         panel["datasource"]["uid"] = "${lokids}"
                     elif dstype == "prometheus":
                         panel["datasource"]["uid"] = "${prometheusds}"
                     else:
-                        logger.debug("Can not determine type of datasource: {}: skipping")
+                        logger.debug("Unrecognized datasource type '%s'; skipping", dstype)
                         continue
                 else:
                     logger.error("Unknown datasource format: skipping")
@@ -655,7 +656,7 @@ def _replace_template_fields(  # noqa: C901
                         used_replacements.append(ds)
                     panel["datasource"] = replacement or panel["datasource"]
                 elif type(panel["datasource"]) == dict:
-                    dstype = panel["datasource"].get("type")
+                    dstype = panel["datasource"].get("type", "")
                     if dstype == "loki":
                         panel["datasource"]["uid"] = "${lokids}"
                     elif dstype == "prometheus":

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -565,7 +565,7 @@ def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> st
     existing_templates = False
 
     template_dropdowns = (
-        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS
+        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS  # type: ignore
         if inject_dropdowns
         else DATASOURCE_TEMPLATE_DROPDOWNS
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ profile = "black"
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99
-max-complexity = 10
 exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -294,6 +294,35 @@ EXISTING_LOKI_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
     }
 )
 
+DICT_DATASOURCE_DASHBOARD_TEMPLATE = """
+{
+    "panels": [
+        {
+            "data": "label_values(up, juju_unit)",
+            "datasource": {
+                "type": "prometheus",
+                "uid": "someuid"
+            }
+        }
+    ]
+}
+"""
+
+DICT_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
+    {
+        "panels": [
+            {
+                "data": "label_values(up, juju_unit)",
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${prometheusds}",
+                },
+            },
+        ],
+        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+    }
+)
+
 
 class ConsumerCharm(CharmBase):
     _stored = StoredState()
@@ -573,6 +602,24 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": NULL_DATASOURCE_DASHBOARD_RENDERED,
+                }
+            ],
+        )
+
+    def test_consumer_templates_with_dict_datasource(self):
+        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        self.setup_different_dashboard(DICT_DATASOURCE_DASHBOARD_TEMPLATE)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
+
+        self.assertEqual(
+            self.harness.charm.grafana_consumer.dashboards,
+            [
+                {
+                    "id": "file:tester",
+                    "relation_id": "2",
+                    "charm": "grafana-k8s",
+                    "content": DICT_DATASOURCE_DASHBOARD_RENDERED,
                 }
             ],
         )

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -607,6 +607,7 @@ class TestDashboardConsumer(unittest.TestCase):
         )
 
     def test_consumer_templates_with_dict_datasource(self):
+        """Dict datasources replace str datasources in Grafana 9."""
         self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
         self.setup_different_dashboard(DICT_DATASOURCE_DASHBOARD_TEMPLATE)

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    mypy >= 0.991
+    mypy
     types-dataclasses
     types-PyYAML
     types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    mypy
+    mypy >= 0.991
     types-dataclasses
     types-PyYAML
     types-requests


### PR DESCRIPTION
## Issue
Fixes #155 


## Solution
New code paths depending on the type of datasource.


## Testing Instructions
Export a dashboard from grafana 9 and attempt to bundle it with a charm.


## Release Notes
Fixed an issue where the grafana-dashboard relation did not work with dashboards exported from Grafana 9