### PR TITLE
Allow builtin datasources

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -218,7 +218,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 logger = logging.getLogger(__name__)
 
@@ -668,6 +668,8 @@ def _template_panels(
             if type(datasource) == str:
                 if "loki" in datasource:
                     panel["datasource"] = "${lokids}"
+                elif "grafana" in datasource:
+                    continue
                 else:
                     panel["datasource"] = "${prometheusds}"
             elif type(datasource) == dict:
@@ -690,6 +692,11 @@ def _template_panels(
                     continue
                 # Strip out variable characters and maybe braces
                 ds = re.sub(r"(\$|\{|\})", "", panel["datasource"])
+
+                if ds not in datasources.keys():
+                    # Unknown, non-templated datasource, potentially a Grafana builtin
+                    continue
+
                 replacement = replacements.get(datasources[ds], "")
                 if replacement:
                     used_replacements.append(ds)
@@ -701,6 +708,11 @@ def _template_panels(
                     continue
                 # Strip out variable characters and maybe braces
                 ds = re.sub(r"(\$|\{|\})", "", panel["datasource"].get("uid", ""))
+
+                if ds not in datasources.keys():
+                    # Unknown, non-templated datasource, potentially a Grafana builtin
+                    continue
+
                 replacement = replacements.get(datasources[ds], "")
                 if replacement:
                     used_replacements.append(ds)

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -179,6 +179,51 @@ NULL_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
     }
 )
 
+BUILTIN_DATASOURCE_DASHBOARD_TEMPLATE = """
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "grafana",
+                "enable": true,
+                "type": "dashboard"
+            }
+        ]
+    },
+    "panels": [
+        {
+            "datasource": "grafana",
+            "panels": [],
+            "targets": [
+                {
+                    "datasource": "grafana",
+                    "refId": "A"
+                }
+            ],
+            "title": "foo"
+        }
+    ]
+}
+"""
+
+BUILTIN_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
+    {
+        "annotations": {
+            "list": [{"builtIn": 1, "datasource": "grafana", "enable": True, "type": "dashboard"}]
+        },
+        "panels": [
+            {
+                "datasource": "grafana",
+                "panels": [],
+                "targets": [{"datasource": "grafana", "refId": "A"}],
+                "title": "foo",
+            }
+        ],
+        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+    }
+)
+
 EXISTING_VARIABLE_DASHBOARD_TEMPLATE = """
 {
     "panels": [
@@ -660,6 +705,24 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": NULL_DATASOURCE_DASHBOARD_RENDERED,
+                }
+            ],
+        )
+
+    def test_consumer_templates_with_builtin_datasource(self):
+        self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        self.setup_different_dashboard(BUILTIN_DATASOURCE_DASHBOARD_TEMPLATE)
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
+
+        self.assertEqual(
+            self.harness.charm.grafana_consumer.dashboards,
+            [
+                {
+                    "id": "file:tester",
+                    "relation_id": "2",
+                    "charm": "grafana-k8s",
+                    "content": BUILTIN_DATASOURCE_DASHBOARD_RENDERED,
                 }
             ],
         )


### PR DESCRIPTION
## Issue
If "builtin" datasource types are used, _and_ they are not dict/object datasource in panels where the type can be inferred (as not-Prometheus|Loki, which is already handled correctly), they may not be caught by the logic to collate and substitute datasources.

Closes #173 

## Solution
Ensure that keys exist before trying to replace values, and if it's an "old-style" datasource as a raw string, if it matches "Grafana" (since others may be unknown), don't replace it with `${prometheusds}` even if no existing template variables are found.

## Context
See [here](https://github.com/canonical/traefik-k8s-operator/pull/104#issuecomment-1372310848) for the discovery of this issue.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
Allow builtin datasources