### PR TITLE
Add handling for mimir datasources

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -218,7 +218,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 22
 
 logger = logging.getLogger(__name__)
 
@@ -1047,7 +1047,7 @@ class GrafanaDashboardProvider(Object):
         self._dashboards_path = dashboards_path
 
         # No peer relation bucket we can rely on providers, keep StoredState here, too
-        self._stored.set_default(dashboard_templates={})
+        self._stored.set_default(dashboard_templates={})  # type: ignore
 
         self.framework.observe(self._charm.on.leader_elected, self._update_all_dashboards_from_dir)
         self.framework.observe(self._charm.on.upgrade_charm, self._update_all_dashboards_from_dir)
@@ -1073,7 +1073,7 @@ class GrafanaDashboardProvider(Object):
         """
         # Update of storage must be done irrespective of leadership, so
         # that the stored state is there when this unit becomes leader.
-        stored_dashboard_templates = self._stored.dashboard_templates
+        stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
 
         encoded_dashboard = _encode_dashboard_content(content)
 
@@ -1094,7 +1094,7 @@ class GrafanaDashboardProvider(Object):
         """Remove all dashboards to the relation added via :method:`add_dashboard`."""
         # Update of storage must be done irrespective of leadership, so
         # that the stored state is there when this unit becomes leader.
-        stored_dashboard_templates = self._stored.dashboard_templates
+        stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
 
         for dashboard_id in list(stored_dashboard_templates.keys()):
             if dashboard_id.startswith("prog:"):
@@ -1121,7 +1121,7 @@ class GrafanaDashboardProvider(Object):
         # Ensure we do not leave outdated dashboards by removing from stored all
         # the encoded dashboards that start with "file/".
         if self._dashboards_path:
-            stored_dashboard_templates = self._stored.dashboard_templates
+            stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
 
             for dashboard_id in list(stored_dashboard_templates.keys()):
                 if dashboard_id.startswith("file:"):
@@ -1175,7 +1175,7 @@ class GrafanaDashboardProvider(Object):
                 e.grafana_dashboards_absolute_path,
                 e.message,
             )
-            stored_dashboard_templates = self._stored.dashboard_templates
+            stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
 
             for dashboard_id in list(stored_dashboard_templates.keys()):
                 if dashboard_id.startswith("file:"):
@@ -1205,7 +1205,7 @@ class GrafanaDashboardProvider(Object):
             event: The `RelationChangedEvent` that triggered this handler.
         """
         if self._charm.unit.is_leader():
-            data = json.loads(event.relation.data[event.app].get("event", "{}"))
+            data = json.loads(event.relation.data[event.app].get("event", "{}"))  # type: ignore
 
             if not data:
                 return
@@ -1251,7 +1251,7 @@ class GrafanaDashboardProvider(Object):
     @property
     def dashboard_templates(self) -> List:
         """Return a list of the known dashboard templates."""
-        return [v for v in self._stored.dashboard_templates.values()]
+        return [v for v in self._stored.dashboard_templates.values()]  # type: ignore
 
 
 class GrafanaDashboardConsumer(Object):
@@ -1305,7 +1305,7 @@ class GrafanaDashboardConsumer(Object):
         self._relation_name = relation_name
         self._tranformer = CosTool(self._charm)
 
-        self._stored.set_default(dashboards=dict())
+        self._stored.set_default(dashboards=dict())  # type: ignore
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
@@ -1630,7 +1630,7 @@ class GrafanaDashboardAggregator(Object):
 
         # Reactive charms may be RPC-ish and not leave reliable data around. Keep
         # StoredState here
-        self._stored.set_default(
+        self._stored.set_default(  # type: ignore
             dashboard_templates={},
             id_mappings={},
         )
@@ -1672,11 +1672,11 @@ class GrafanaDashboardAggregator(Object):
             return
 
         for id in dashboards:
-            self._stored.dashboard_templates[id] = self._content_to_dashboard_object(
+            self._stored.dashboard_templates[id] = self._content_to_dashboard_object(  # type: ignore
                 dashboards[id], event
             )
 
-        self._stored.id_mappings[event.app.name] = dashboards
+        self._stored.id_mappings[event.app.name] = dashboards  # type: ignore
         self._update_remote_grafana(event)
 
     def _update_remote_grafana(self, _: Optional[RelationEvent] = None) -> None:
@@ -1692,11 +1692,11 @@ class GrafanaDashboardAggregator(Object):
 
     def remove_dashboards(self, event: RelationBrokenEvent) -> None:
         """Remove a dashboard if the relation is broken."""
-        app_ids = _type_convert_stored(self._stored.id_mappings[event.app.name])
+        app_ids = _type_convert_stored(self._stored.id_mappings[event.app.name])  # type: ignore
 
-        del self._stored.id_mappings[event.app.name]
+        del self._stored.id_mappings[event.app.name]  # type: ignore
         for id in app_ids:
-            del self._stored.dashboard_templates[id]
+            del self._stored.dashboard_templates[id]  # type: ignore
 
         stored_data = {
             "templates": _type_convert_stored(self._stored.dashboard_templates),
@@ -1764,13 +1764,13 @@ class GrafanaDashboardAggregator(Object):
         # Reactive data can reliably be pulled out of events. In theory, if we got an event,
         # it's on the bucket, but using event explicitly keeps the mental model in
         # place for reactive
-        for k in event.relation.data[event.unit].keys():
+        for k in event.relation.data[event.unit].keys():  # type: ignore
             if k.startswith("request_"):
-                templates.append(json.loads(event.relation.data[event.unit][k])["dashboard"])
+                templates.append(json.loads(event.relation.data[event.unit][k])["dashboard"])  # type: ignore
 
-        for k in event.relation.data[event.app].keys():
+        for k in event.relation.data[event.app].keys():  # type: ignore
             if k.startswith("request_"):
-                templates.append(json.loads(event.relation.data[event.app][k])["dashboard"])
+                templates.append(json.loads(event.relation.data[event.app][k])["dashboard"])  # type: ignore
 
         builtins = self._maybe_get_builtin_dashboards(event)
 
@@ -1797,7 +1797,7 @@ class GrafanaDashboardAggregator(Object):
             from jinja2 import Template
 
             content = _encode_dashboard_content(
-                Template(dash).render(host=event.unit.name, datasource="prometheus")
+                Template(dash).render(host=event.unit.name, datasource="prometheus")  # type: ignore
             )
             id = "prog:{}".format(content[-24:-16])
 
@@ -1833,7 +1833,7 @@ class GrafanaDashboardAggregator(Object):
 
             for path in filter(_is_dashboard, Path(dashboards_path).glob("*")):
                 # path = Path(path)
-                if event.app.name in path.name:
+                if event.app.name in path.name:  # type: ignore
                     id = "file:{}".format(path.stem)
                     builtins[id] = self._content_to_dashboard_object(
                         _encode_dashboard_content(path.read_bytes()), event
@@ -1843,7 +1843,7 @@ class GrafanaDashboardAggregator(Object):
 
     def _content_to_dashboard_object(self, content: str, event: RelationEvent) -> Dict:
         return {
-            "charm": event.app.name,
+            "charm": event.app.name,  # type: ignore
             "content": content,
             "juju_topology": self._juju_topology(event),
             "inject_dropdowns": True,
@@ -1856,8 +1856,8 @@ class GrafanaDashboardAggregator(Object):
         return {
             "model": self._charm.model.name,
             "model_uuid": self._charm.model.uuid,
-            "application": event.app.name,
-            "unit": event.unit.name,
+            "application": event.app.name,  # type: ignore
+            "unit": event.unit.name,  # type: ignore
         }
 
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -498,7 +498,7 @@ class GrafanaSourceConsumer(Object):
 
         # We're stuck with this forever now so upgrades work, or until such point as we can
         # break compatibility
-        self._stored.set_default(
+        self._stored.set_default(  # type: ignore
             sources=dict(),
             sources_to_delete=set(),
         )
@@ -667,13 +667,13 @@ class GrafanaSourceConsumer(Object):
                 )
 
         # If there's stored data, merge it and purge it
-        if self._stored.sources:
+        if self._stored.sources:  # type: ignore
             self._stored.sources = {}
             peer_sources = self.get_peer_data("sources")
             sources.update(peer_sources)
             self.set_peer_data("sources", sources)
 
-        if self._stored.sources_to_delete:
+        if self._stored.sources_to_delete:  # type: ignore
             old_sources_to_delete = _type_convert_stored(self._stored.sources_to_delete)
             self._stored.sources_to_delete = set()
             peer_sources_to_delete = set(self.get_peer_data("sources_to_delete"))

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -160,7 +160,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 logger = logging.getLogger(__name__)
 
@@ -459,6 +459,9 @@ class GrafanaSourceProvider(Object):
         """
         for relation in self._charm.model.relations[self._relation_name]:
             url = self._source_url or "{}:{}".format(socket.getfqdn(), self._source_port)
+            if self._source_type == "mimir":
+                url = f"{url}/prometheus"
+
             relation.data[self._charm.unit]["grafana_source_host"] = url
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,12 +64,12 @@ deps =
     types-PyYAML
     types-requests
     charm: -r{toxinidir}/requirements.txt
-    lib: ops==1.5.2
+    lib: ops
     unit: {[testenv:unit]deps}
     integration: {[testenv:integration]deps}
 commands =
     charm: mypy {[vars]src_path} {posargs}
-    lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    lib: mypy --python-version 3.8 {[vars]lib_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
## Issue
Add support for Mimir to `GrafanaSourceProvider`.

## Solution
Mimir needs a little special handling. It's ok for the client to provide the type and the port, but _if_ it's mimir, it needs a `/prometheus` endpoint tacked on to query.

## Context
See [here](https://grafana.com/docs/mimir/latest/operators-guide/get-started/)


## Release Notes
Add handling for mimir datasources