### PR TITLE
[DO NOT MERGE] fix: do not use exit(0) in compute resource patch

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,9 +5,29 @@ on:
     branches:
       - main
 
-jobs:
-  pull-request:
-    name: PR
-    uses: canonical/observability/.github/workflows/pull-request.yaml@main
-    secrets: inherit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Get prefsrc
+        run: |
+          echo "IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')" >> $GITHUB_ENV
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          channel: 1.26-strict/stable
+          juju-channel: 3.1/edge
+          microk8s-group: snap_microk8s
+          microk8s-addons: "hostpath-storage dns metallb:${{ env.IPADDR }}-${{ env.IPADDR }}"
+      - name: Run integration tests
+        run: tox -vve integration

--- a/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_compute_resources_patch.py
@@ -103,8 +103,6 @@ References:
 
 import decimal
 import logging
-import signal
-import sys
 from decimal import Decimal
 from math import ceil, floor
 from typing import Callable, Dict, List, Optional, Union
@@ -403,27 +401,12 @@ class ResourcePatcher:
             resource_reqs, self.get_actual(pod_name)
         )
 
-    def _handle_pod_termination(self, *args) -> None:
-        logger.debug(
-            "KubernetesComputeResourcesPatch's signal handler caught a SIGTERM, likely due to "
-            "pod termination during execution of `config-changed`. Exiting gracefully. "
-            "The hook being executed will be re-run by Juju once the pod is re-scheduled."
-        )
-        sys.exit(0)
-
     def apply(self, resource_reqs: ResourceRequirements) -> None:
         """Patch the Kubernetes resources created by Juju to limit cpu or mem."""
         # Need to ignore invalid input, otherwise the StatefulSet gives "FailedCreate" and the
         # charm would be stuck in unknown/lost.
         if self.is_patched(resource_reqs):
             return
-
-        # If it's not patched already, add a handler for SIGTERM prior to patching.
-        # Juju tries to send a SIGTERM to the CRI to exit gracefully when in CAAS mode, then
-        # the hook is re-executed, so we can "safely" trap it here without causing a hook
-        # failure if there is a race, and config-changed will retry (after it is applied and
-        # the pod is rescheduled)
-        signal.signal(signal.SIGTERM, self._handle_pod_termination)
 
         self.client.patch(
             StatefulSet,

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ description = Run integration tests
 deps =
     aiohttp
     asyncstdlib
-    juju ~= 3.0.0
+    juju ~= 3.1.0
     pytest
     pytest-operator
 commands =


### PR DESCRIPTION
Testing what happens if we remove the sigterm handler in the compute resources library. Also hacked on the Github workflow to simplify for testing with the right juju version