### PR TITLE
Handle empty keys on removal and in prometheus-ceph-exporter dashboards better

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 26
+LIBPATCH = 27
 
 logger = logging.getLogger(__name__)
 
@@ -1691,7 +1691,11 @@ class GrafanaDashboardAggregator(Object):
 
     def remove_dashboards(self, event: RelationBrokenEvent) -> None:
         """Remove a dashboard if the relation is broken."""
-        app_ids = _type_convert_stored(self._stored.id_mappings[event.app.name])  # type: ignore
+        app_ids = _type_convert_stored(self._stored.id_mappings.get(event.app.name, ""))  # type: ignore
+
+        if not app_ids:
+            logger.info("Could not look up stored dashboards for %s", event.app.name)  # type: ignore
+            return
 
         del self._stored.id_mappings[event.app.name]  # type: ignore
         for id in app_ids:
@@ -1731,14 +1735,16 @@ class GrafanaDashboardAggregator(Object):
                 for i in range(len(dash["templating"]["list"])):
                     if (
                         "datasource" in dash["templating"]["list"][i]
-                        and "Juju" in dash["templating"]["list"][i]["datasource"]
+                        and dash["templating"]["list"][i]["datasource"] is not None
                     ):
-                        dash["templating"]["list"][i]["datasource"] = r"${prometheusds}"
+                        if "Juju" in dash["templating"]["list"][i].get("datasource", ""):
+                            dash["templating"]["list"][i]["datasource"] = r"${prometheusds}"
                     if (
                         "name" in dash["templating"]["list"][i]
-                        and dash["templating"]["list"][i]["name"] == "host"
+                        and dash["templating"]["list"][i]["name"] is not None
                     ):
-                        dash["templating"]["list"][i] = REACTIVE_CONVERTER
+                        if dash["templating"]["list"][i].get("name", "") == "host":
+                            dash["templating"]["list"][i] = REACTIVE_CONVERTER
 
                 # Strip out newly-added 'juju_application' template variables which
                 # don't line up with our drop-downs
@@ -1746,7 +1752,7 @@ class GrafanaDashboardAggregator(Object):
                 for i in range(len(dash["templating"]["list"])):
                     if (
                         "name" in dash["templating"]["list"][i]
-                        and dash["templating"]["list"][i]["name"] == "app"
+                        and dash["templating"]["list"][i].get("name", "") == "app"
                     ):
                         del dash_mutable["templating"]["list"][i]
 
@@ -1758,7 +1764,7 @@ class GrafanaDashboardAggregator(Object):
         if "__inputs" in dash:
             inputs = dash
             for i in range(len(dash["__inputs"])):
-                if dash["__inputs"][i]["pluginName"] == "Prometheus":
+                if dash["__inputs"][i].get("pluginName", "") == "Prometheus":
                     del inputs["__inputs"][i]
             if inputs:
                 dash["__inputs"] = inputs["__inputs"]

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1739,12 +1739,12 @@ class GrafanaDashboardAggregator(Object):
                     ):
                         if "Juju" in dash["templating"]["list"][i].get("datasource", ""):
                             dash["templating"]["list"][i]["datasource"] = r"${prometheusds}"
-                    if (
-                        "name" in dash["templating"]["list"][i]
-                        and dash["templating"]["list"][i]["name"] is not None
-                    ):
-                        if dash["templating"]["list"][i].get("name", "") == "host":
-                            dash["templating"]["list"][i] = REACTIVE_CONVERTER
+                    # if (
+                    #     "name" in dash["templating"]["list"][i]
+                    #     and dash["templating"]["list"][i]["name"] is not None
+                    # ):
+                    #     if dash["templating"]["list"][i].get("name", "") == "host":
+                    #         dash["templating"]["list"][i] = REACTIVE_CONVERTER
 
                 # Strip out newly-added 'juju_application' template variables which
                 # don't line up with our drop-downs
@@ -1819,13 +1819,22 @@ class GrafanaDashboardAggregator(Object):
             dash = re.sub(r"<< datasource >>", r"${prometheusds}", dash)
             dash = re.sub(r'"datasource": "prom.*?"', r'"datasource": "${prometheusds}"', dash)
             dash = re.sub(
+                r'"datasource": "\$datasource"', r'"datasource": "${prometheusds}"', dash
+            )
+            dash = re.sub(r'"uid": "\$datasource"', r'"uid": "${prometheusds}"', dash)
+            dash = re.sub(
                 r'"datasource": "(!?\w)[\w|\s|-]+?Juju generated.*?"',
                 r'"datasource": "${prometheusds}"',
                 dash,
             )
 
             # Yank out "new"+old LMA topology
-            dash = re.sub(r'(,?juju_application=~)"\$app"', r'\1"\$juju_application"', dash)
+            dash = re.sub(
+                r'(,?\s?juju_application=~)\\"\$app\\"', r'\1\\"$juju_application\\"', dash
+            )
+
+            # Replace old piechart panels
+            dash = re.sub(r'"type": "grafana-piechart-panel"', '"type": "piechart"', dash)
 
             from jinja2 import Template
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1739,12 +1739,6 @@ class GrafanaDashboardAggregator(Object):
                     ):
                         if "Juju" in dash["templating"]["list"][i].get("datasource", ""):
                             dash["templating"]["list"][i]["datasource"] = r"${prometheusds}"
-                    # if (
-                    #     "name" in dash["templating"]["list"][i]
-                    #     and dash["templating"]["list"][i]["name"] is not None
-                    # ):
-                    #     if dash["templating"]["list"][i].get("name", "") == "host":
-                    #         dash["templating"]["list"][i] = REACTIVE_CONVERTER
 
                 # Strip out newly-added 'juju_application' template variables which
                 # don't line up with our drop-downs


### PR DESCRIPTION
Log an error if a key can't be found when removing a dashboard (if more than one exporter is related, the event.app.name will be the same, and the first relation-broken will purge it, as these seem to fire more than once in subordinates).

prometheus-ceph-exporter sends dashboards with None as explicit templating keys, which passes (theoretically) since the key exists, but None is not iterable. Add explicit None checks.
