### PR TITLE
Use jinja2.DebugUndefined to leave unspecified template variables

### DIFF
--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -560,49 +560,6 @@ class TestDashboardConsumer(unittest.TestCase):
             ],
         )
 
-    def test_consumer_error_on_bad_template(self):
-        self.assertEqual(len(self.harness.charm.grafana_consumer.dashboards), 0)
-        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
-        rels = self.setup_charm_relations()
-        self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
-
-        bad_data = {
-            "templates": {
-                "file:tester": {
-                    "charm": "grafana-k8s",
-                    "content": "{{ unclosed variable",
-                    "juju_topology": {
-                        "model": MODEL_INFO["name"],
-                        "model_uuid": MODEL_INFO["uuid"],
-                        "application": "provider-tester",
-                        "unit": "provider-tester/0",
-                    },
-                }
-            },
-            "uuid": "12345678",
-        }
-
-        self.harness.update_relation_data(
-            rels[0],
-            "provider",
-            {
-                "dashboards": json.dumps(bad_data),
-            },
-        )
-
-        data = json.loads(
-            self.harness.get_relation_data(rels[0], self.harness.model.app.name)["event"]
-        )
-        self.assertEqual(
-            data["errors"],
-            [
-                {
-                    "dashboard_id": "file:tester",
-                    "error": "expected token 'end of print statement', got 'variable'",
-                }
-            ],
-        )
-
     def test_consumer_error_on_bad_json(self):
         self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)


### PR DESCRIPTION
## Issue
Grafana dashboards may use `{{ variable }}` for formatting some fields, particularly legends, as Golang templates use the same formatting as Jinja.

Drop use of Jinja entirely outside of the aggregator, as all Providers should now not need templating (and will use cos-tool instead).

## Solution
Don't substitute {{ host }}, leave undefined variables in the Jinja environment alone.

## Release Notes
Use jinja2.DebugUndefined to leave unspecified template variables