### PR TITLE
Add integration with oauth

### DIFF
--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -710,4 +710,3 @@ class OAuthProvider(Object):
         secret = self._create_juju_secret(client_secret, relation)
         data = dict(client_id=client_id, client_secret_id=secret.id)
         relation.data[self.model.app].update(_dump_data(data))
-

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 
@@ -441,8 +441,6 @@ class OAuthRequirer(Object):
         self, client_config: ClientConfig, relation_id: Optional[int] = None
     ) -> None:
         """Update the client config stored in the object."""
-        if len(self.model.relations) == 0:
-            return
         self._client_config = client_config
         self._update_relation_data(client_config, relation_id=relation_id)
 
@@ -712,3 +710,4 @@ class OAuthProvider(Object):
         secret = self._create_juju_secret(client_secret, relation)
         data = dict(client_id=client_id, client_secret_id=secret.id)
         relation.data[self.model.app].update(_dump_data(data))
+

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -1,0 +1,686 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# Oauth Library.
+
+This library is designed to enable applications to register OAuth2/OIDC
+clients with an OIDC Provider through the `oauth` interface.
+
+## Getting started
+
+To get started using this library you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `jsonschema` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.hydra.v0.oauth
+EOF
+```
+
+Then, to initialize the library:
+```python
+# ...
+from charms.hydra.v0.oauth import ClientConfig, OAuthRequirer
+
+OAUTH = "oauth"
+OAUTH_SCOPES = "openid email"
+OAUTH_GRANT_TYPES = ["authorization_code"]
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.oauth = OAuthRequirer(self, client_config, relation_name=OAUTH)
+
+    self.framework.observe(self.oauth.on.oauth_info_changed, self._configure_application)
+    # ...
+
+    def _on_ingress_ready(self, event):
+        self.external_url = "https://example.com"
+        self._set_client_config()
+
+    def _set_client_config(self):
+        client_config = ClientConfig(
+            urljoin(self.external_url, "/oauth/callback"),
+            OAUTH_SCOPES,
+            OAUTH_GRANT_TYPES,
+        )
+        self.oauth.update_client_config(client_config)
+```
+"""
+
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Mapping, Optional
+
+import jsonschema
+from ops.charm import CharmBase, RelationChangedEvent, RelationCreatedEvent, RelationDepartedEvent
+from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents
+from ops.model import Relation, Secret, TooManyRelatedAppsError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a3a301e325e34aac80a2d633ef61fe97"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "oauth"
+ALLOWED_GRANT_TYPES = ["authorization_code", "refresh_token", "client_credentials"]
+ALLOWED_CLIENT_AUTHN_METHODS = ["client_secret_basic", "client_secret_post"]
+CLIENT_SECRET_FIELD = "secret"
+
+url_regex = re.compile(
+    r"(^http://)|(^https://)"  # http:// or https://
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|"
+    r"[A-Z0-9-]{2,}\.?)|"  # domain...
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+    r"(?::\d+)?"  # optional port
+    r"(?:/?|[/?]\S+)$",
+    re.IGNORECASE,
+)
+
+OAUTH_PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/oauth/schemas/provider.json",
+    "type": "object",
+    "properties": {
+        "issuer_url": {
+            "type": "string",
+        },
+        "authorization_endpoint": {
+            "type": "string",
+        },
+        "token_endpoint": {
+            "type": "string",
+        },
+        "introspection_endpoint": {
+            "type": "string",
+        },
+        "userinfo_endpoint": {
+            "type": "string",
+        },
+        "jwks_endpoint": {
+            "type": "string",
+        },
+        "scope": {
+            "type": "string",
+        },
+        "client_id": {
+            "type": "string",
+        },
+        "client_secret_id": {
+            "type": "string",
+        },
+        "groups": {"type": "string", "default": None},
+        "ca_chain": {"type": "array", "items": {"type": "string"}, "default": []},
+    },
+    "required": [
+        "issuer_url",
+        "authorization_endpoint",
+        "token_endpoint",
+        "introspection_endpoint",
+        "userinfo_endpoint",
+        "jwks_endpoint",
+        "scope",
+    ],
+}
+OAUTH_REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/oauth/schemas/requirer.json",
+    "type": "object",
+    "properties": {
+        "redirect_uri": {
+            "type": "string",
+            "default": None,
+        },
+        "audience": {"type": "array", "default": [], "items": {"type": "string"}},
+        "scope": {"type": "string", "default": None},
+        "grant_types": {
+            "type": "array",
+            "default": None,
+            "items": {
+                "enum": ["authorization_code", "client_credentials", "refresh_token"],
+                "type": "string",
+            },
+        },
+        "token_endpoint_auth_method": {
+            "type": "string",
+            "enum": ["client_secret_basic", "client_secret_post"],
+            "default": "client_secret_basic",
+        },
+    },
+    "required": ["redirect_uri", "audience", "scope", "grant_types", "token_endpoint_auth_method"],
+}
+
+
+class ClientConfigError(Exception):
+    """Emitted when invalid client config is provided."""
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on relation data."""
+
+
+def _load_data(data: Mapping, schema: Optional[Dict] = None) -> Dict:
+    """Parses nested fields and checks whether `data` matches `schema`."""
+    ret = {}
+    for k, v in data.items():
+        try:
+            ret[k] = json.loads(v)
+        except json.JSONDecodeError:
+            ret[k] = v
+
+    if schema:
+        _validate_data(ret, schema)
+    return ret
+
+
+def _dump_data(data: Dict, schema: Optional[Dict] = None) -> Dict:
+    if schema:
+        _validate_data(data, schema)
+
+    ret = {}
+    for k, v in data.items():
+        if isinstance(v, (list, dict)):
+            try:
+                ret[k] = json.dumps(v)
+            except json.JSONDecodeError as e:
+                raise DataValidationError(f"Failed to encode relation json: {e}")
+        else:
+            ret[k] = v
+    return ret
+
+
+def _validate_data(data: Dict, schema: Dict) -> None:
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+@dataclass
+class ClientConfig:
+    """Helper class containing a client's configuration."""
+
+    redirect_uri: str
+    scope: str
+    grant_types: List[str]
+    audience: List[str] = field(default_factory=lambda: [])
+    token_endpoint_auth_method: str = "client_secret_basic"
+    client_id: Optional[str] = None
+
+    def validate(self) -> None:
+        """Validate the client configuration."""
+        # Validate redirect_uri
+        if not re.match(url_regex, self.redirect_uri):
+            raise ClientConfigError(f"Invalid URL {self.redirect_uri}")
+
+        if self.redirect_uri.startswith("http://"):
+            logger.warning("Provided Redirect URL uses http scheme. Don't do this in production")
+
+        # Validate grant_types
+        for grant_type in self.grant_types:
+            if grant_type not in ALLOWED_GRANT_TYPES:
+                raise ClientConfigError(
+                    f"Invalid grant_type {grant_type}, must be one " f"of {ALLOWED_GRANT_TYPES}"
+                )
+
+        # Validate client authentication methods
+        if self.token_endpoint_auth_method not in ALLOWED_CLIENT_AUTHN_METHODS:
+            raise ClientConfigError(
+                f"Invalid client auth method {self.token_endpoint_auth_method}, "
+                f"must be one of {ALLOWED_CLIENT_AUTHN_METHODS}"
+            )
+
+    def to_dict(self) -> Dict:
+        """Convert object to dict."""
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+class OAuthInfoChangedEvent(EventBase):
+    """Event to notify the charm that the information in the databag changed."""
+
+    def __init__(self, handle: Handle, client_id: str, client_secret_id: str):
+        super().__init__(handle)
+        self.client_id = client_id
+        self.client_secret_id = client_secret_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "client_id": self.client_id,
+            "client_secret_id": self.client_secret_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.client_id = snapshot["client_id"]
+        self.client_secret_id = snapshot["client_secret_id"]
+
+
+class InvalidClientConfigEvent(EventBase):
+    """Event to notify the charm that the client configuration is invalid."""
+
+    def __init__(self, handle: Handle, error: str):
+        super().__init__(handle)
+        self.error = error
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "error": self.error,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.error = snapshot["error"]
+
+
+class OAuthRequirerEvents(ObjectEvents):
+    """Event descriptor for events raised by `OAuthRequirerEvents`."""
+
+    oauth_info_changed = EventSource(OAuthInfoChangedEvent)
+    invalid_client_config = EventSource(InvalidClientConfigEvent)
+
+
+class OAuthRequirer(Object):
+    """Register an oauth client."""
+
+    on = OAuthRequirerEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        client_config: Optional[ClientConfig] = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._client_config = client_config
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_relation_created_event)
+        self.framework.observe(events.relation_changed, self._on_relation_changed_event)
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        try:
+            self._update_relation_data(self._client_config, event.relation.id)
+        except ClientConfigError as e:
+            self.on.invalid_client_config.emit(e.args[0])
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+
+        client_id = data.get("client_id")
+        client_secret_id = data.get("client_secret_id")
+        if not client_id or not client_secret_id:
+            logger.info("OAuth Provider info is available, waiting for client to be registered.")
+            # The client credentials are not ready yet, so we do nothing
+            # This could mean that the client credentials were removed from the databag,
+            # but we don't allow that (for now), so we don't have to check for it.
+            return
+
+        self.on.oauth_info_changed.emit(client_id, client_secret_id)
+
+    def _update_relation_data(
+        self, client_config: Optional[ClientConfig], relation_id: Optional[int] = None
+    ) -> None:
+        if not self.model.unit.is_leader() or not client_config:
+            return
+
+        if not isinstance(client_config, ClientConfig):
+            raise ValueError(f"Unexpected client_config type: {type(client_config)}")
+
+        client_config.validate()
+
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        if not relation:
+            return
+
+        data = _dump_data(client_config.to_dict(), OAUTH_REQUIRER_JSON_SCHEMA)
+        relation.data[self.model.app].update(data)
+
+    def get_provider_info(self, relation_id: Optional[int] = None) -> Optional[Dict]:
+        """Get the provider information from the databag."""
+        if len(self.model.relations) == 0:
+            return None
+        try:
+            relation = self.model.get_relation(self._relation_name, relation_id=relation_id)
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+        if not relation:
+            return None
+
+        data = relation.data[relation.app]
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+        data.pop("client_id", None)
+        data.pop("client_secret_id", None)
+        return data
+
+    def get_client_secret(self, client_secret_id: str) -> Secret:
+        """Get the client_secret."""
+        client_secret = self.model.get_secret(id=client_secret_id)
+        return client_secret
+
+    def get_client_credentials(self, relation_id: Optional[int] = None) -> Optional[Dict]:
+        """Get the client credentials."""
+        try:
+            relation = self.model.get_relation(
+                relation_name=self._relation_name, relation_id=relation_id
+            )
+        except TooManyRelatedAppsError:
+            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
+
+        data = _load_data(relation.data[relation.app], OAUTH_PROVIDER_JSON_SCHEMA)
+
+        client_id = data.get("client_id")
+        client_secret_id = data.get("client_secret_id")
+        if not client_id or not client_secret_id:
+            return None
+
+        _client_secret = self.get_client_secret(client_secret_id)
+        client_secret = _client_secret.get_content()[CLIENT_SECRET_FIELD]
+        return dict(client_id=client_id, client_secret=client_secret)
+
+    def update_client_config(
+        self, client_config: ClientConfig, relation_id: Optional[int] = None
+    ) -> None:
+        """Update the client config stored in the object."""
+        self._client_config = client_config
+        self._update_relation_data(client_config, relation_id=relation_id)
+
+
+class ClientCreatedEvent(EventBase):
+    """Event to notify the Provider charm to create a new client."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        redirect_uri: str,
+        scope: str,
+        grant_types: List[str],
+        audience: List,
+        token_endpoint_auth_method: str,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.grant_types = grant_types
+        self.audience = audience
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "grant_types": self.grant_types,
+            "audience": self.audience,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.redirect_uri = snapshot["redirect_uri"]
+        self.scope = snapshot["scope"]
+        self.grant_types = snapshot["grant_types"]
+        self.audience = snapshot["audience"]
+        self.token_endpoint_auth_method = snapshot["token_endpoint_auth_method"]
+        self.relation_id = snapshot["relation_id"]
+
+    def to_client_config(self) -> ClientConfig:
+        """Convert the event information to a ClientConfig object."""
+        return ClientConfig(
+            self.redirect_uri,
+            self.scope,
+            self.grant_types,
+            self.audience,
+            self.token_endpoint_auth_method,
+        )
+
+
+class ClientChangedEvent(EventBase):
+    """Event to notify the Provider charm that the client config changed."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        redirect_uri: str,
+        scope: str,
+        grant_types: List,
+        audience: List,
+        token_endpoint_auth_method: str,
+        relation_id: int,
+        client_id: str,
+    ) -> None:
+        super().__init__(handle)
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.grant_types = grant_types
+        self.audience = audience
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+        self.relation_id = relation_id
+        self.client_id = client_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "grant_types": self.grant_types,
+            "audience": self.audience,
+            "token_endpoint_auth_method": self.token_endpoint_auth_method,
+            "relation_id": self.relation_id,
+            "client_id": self.client_id,
+        }
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.redirect_uri = snapshot["redirect_uri"]
+        self.scope = snapshot["scope"]
+        self.grant_types = snapshot["grant_types"]
+        self.audience = snapshot["audience"]
+        self.token_endpoint_auth_method = snapshot["token_endpoint_auth_method"]
+        self.relation_id = snapshot["relation_id"]
+        self.client_id = snapshot["client_id"]
+
+    def to_client_config(self) -> ClientConfig:
+        """Convert the event information to a ClientConfig object."""
+        return ClientConfig(
+            self.redirect_uri,
+            self.scope,
+            self.grant_types,
+            self.audience,
+            self.token_endpoint_auth_method,
+            self.client_id,
+        )
+
+
+class ClientDeletedEvent(EventBase):
+    """Event to notify the Provider charm that the client was deleted."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        relation_id: int,
+    ) -> None:
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> Dict:
+        """Save event."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: Dict) -> None:
+        """Restore event."""
+        self.relation_id = snapshot["relation_id"]
+
+
+class OAuthProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `OAuthProviderEvents`."""
+
+    client_created = EventSource(ClientCreatedEvent)
+    client_changed = EventSource(ClientChangedEvent)
+    client_deleted = EventSource(ClientDeletedEvent)
+
+
+class OAuthProvider(Object):
+    """A provider object for OIDC Providers."""
+
+    on = OAuthProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(
+            events.relation_changed,
+            self._get_client_config_from_relation_data,
+        )
+        self.framework.observe(
+            events.relation_departed,
+            self._on_relation_departed,
+        )
+
+    def _get_client_config_from_relation_data(self, event: RelationChangedEvent) -> None:
+        if not self.model.unit.is_leader():
+            return
+
+        data = event.relation.data[event.app]
+        if not data:
+            logger.info("No requirer relation data available.")
+            return
+
+        client_data = _load_data(data, OAUTH_REQUIRER_JSON_SCHEMA)
+        redirect_uri = client_data.get("redirect_uri")
+        scope = client_data.get("scope")
+        grant_types = client_data.get("grant_types")
+        audience = client_data.get("audience")
+        token_endpoint_auth_method = client_data.get("token_endpoint_auth_method")
+
+        data = event.relation.data[self._charm.app]
+        if not data:
+            logger.info("No provider relation data available.")
+            return
+        provider_data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+        client_id = provider_data.get("client_id")
+
+        relation_id = event.relation.id
+
+        if client_id:
+            # Modify an existing client
+            self.on.client_changed.emit(
+                redirect_uri,
+                scope,
+                grant_types,
+                audience,
+                token_endpoint_auth_method,
+                relation_id,
+                client_id,
+            )
+        else:
+            # Create a new client
+            self.on.client_created.emit(
+                redirect_uri, scope, grant_types, audience, token_endpoint_auth_method, relation_id
+            )
+
+    def _get_secret_label(self, relation: Relation) -> str:
+        return f"client_secret_{relation.id}"
+
+    def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
+        self._delete_juju_secret(event.relation)
+        self.on.client_deleted.emit(event.relation.id)
+
+    def _create_juju_secret(self, client_secret: str, relation: Relation) -> Secret:
+        """Create a juju secret and grant it to a relation."""
+        secret = {CLIENT_SECRET_FIELD: client_secret}
+        juju_secret = self.model.app.add_secret(secret, label=self._get_secret_label(relation))
+        juju_secret.grant(relation)
+        return juju_secret
+
+    def _delete_juju_secret(self, relation: Relation) -> None:
+        secret = self.model.get_secret(label=self._get_secret_label(relation))
+        secret.remove_all_revisions()
+
+    def set_provider_info_in_relation_data(
+        self,
+        issuer_url: str,
+        authorization_endpoint: str,
+        token_endpoint: str,
+        introspection_endpoint: str,
+        userinfo_endpoint: str,
+        jwks_endpoint: str,
+        scope: str,
+        groups: Optional[str] = None,
+        ca_chain: Optional[str] = None,
+    ) -> None:
+        """Put the provider information in the the databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        data = {
+            "issuer_url": issuer_url,
+            "authorization_endpoint": authorization_endpoint,
+            "token_endpoint": token_endpoint,
+            "introspection_endpoint": introspection_endpoint,
+            "userinfo_endpoint": userinfo_endpoint,
+            "jwks_endpoint": jwks_endpoint,
+            "scope": scope,
+        }
+        if groups:
+            data["groups"] = groups
+        if ca_chain:
+            data["ca_chain"] = ca_chain
+
+        for relation in self.model.relations[self._relation_name]:
+            relation.data[self.model.app].update(_dump_data(data))
+
+    def set_client_credentials_in_relation_data(
+        self, relation_id: int, client_id: str, client_secret: str
+    ) -> None:
+        """Put the client credentials in the databag."""
+        if not self.model.unit.is_leader():
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if not relation:
+            return
+        # TODO: What if we are refreshing the client_secret? We need to add a
+        # new revision for that
+        secret = self._create_juju_secret(client_secret, relation)
+        data = dict(client_id=client_id, client_secret_id=secret.id)
+        relation.data[self.model.app].update(_dump_data(data))

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -260,6 +260,8 @@ class OauthProviderConfig:
     userinfo_endpoint: str
     jwks_endpoint: str
     scope: str
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
     groups: Optional[str] = None
     ca_chain: Optional[str] = None
 
@@ -267,14 +269,6 @@ class OauthProviderConfig:
     def from_dict(cls, dic: Dict) -> "OauthProviderConfig":
         """Generate OauthProviderConfig instance from dict."""
         return cls(**{k: v for k, v in dic.items() if k in inspect.signature(cls).parameters})
-
-
-@dataclass
-class OauthClientCredentials:
-    """Helper class containing client's credentials."""
-
-    client_id: str
-    client_secret: str
 
 
 class OAuthInfoChangedEvent(EventBase):
@@ -428,8 +422,12 @@ class OAuthRequirer(Object):
             return
 
         data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
-        data.pop("client_id", None)
-        data.pop("client_secret_id", None)
+
+        client_secret_id = data.get("client_secret_id")
+        if client_secret_id:
+            _client_secret = self.get_client_secret(client_secret_id)
+            client_secret = _client_secret.get_content()[CLIENT_SECRET_FIELD]
+            data["client_secret"] = client_secret
 
         oauth_provider = OauthProviderConfig.from_dict(data)
         return oauth_provider
@@ -439,30 +437,12 @@ class OAuthRequirer(Object):
         client_secret = self.model.get_secret(id=client_secret_id)
         return client_secret
 
-    def get_client_credentials(self, relation_id: Optional[int] = None) -> OauthClientCredentials:
-        """Get the client credentials."""
-        try:
-            relation = self.model.get_relation(
-                relation_name=self._relation_name, relation_id=relation_id
-            )
-        except TooManyRelatedAppsError:
-            raise RuntimeError("More than one relations are defined. Please provide a relation_id")
-
-        data = _load_data(relation.data[relation.app], OAUTH_PROVIDER_JSON_SCHEMA)
-
-        client_id = data.get("client_id")
-        client_secret_id = data.get("client_secret_id")
-        if not client_id or not client_secret_id:
-            return None
-
-        _client_secret = self.get_client_secret(client_secret_id)
-        client_secret = _client_secret.get_content()[CLIENT_SECRET_FIELD]
-        return OauthClientCredentials(client_id, client_secret)
-
     def update_client_config(
         self, client_config: ClientConfig, relation_id: Optional[int] = None
     ) -> None:
         """Update the client config stored in the object."""
+        if len(self.model.relations) == 0:
+            return
         self._client_config = client_config
         self._update_relation_data(client_config, relation_id=relation_id)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -52,6 +52,8 @@ requires:
     interface: tls-certificates
     limit: 1
     description: Certificate and key files for Grafana to use with TLS.
+  oauth:
+    interface: oauth
 
 provides:
   metrics-endpoint:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -54,6 +54,7 @@ requires:
     description: Certificate and key files for Grafana to use with TLS.
   oauth:
     interface: oauth
+    limit: 1
 
 provides:
   metrics-endpoint:

--- a/src/charm.py
+++ b/src/charm.py
@@ -239,7 +239,9 @@ class GrafanaCharm(CharmBase):
         self.oauth = OAuthRequirer(self, self._oauth_client_config)
 
         # oauth relation observations
-        self.framework.observe(self.oauth.on.oauth_info_changed, self._on_oauth_info_changed)
+        self.framework.observe(
+            self.oauth.on.oauth_info_changed, self._on_oauth_info_changed  # pyright: ignore
+        )
         self.framework.observe(self.on[OAUTH].relation_broken, self._on_oauth_relation_broken)
 
         # self.catalog = CatalogueConsumer(charm=self, item=self._catalogue_item)

--- a/src/charm.py
+++ b/src/charm.py
@@ -274,6 +274,9 @@ class GrafanaCharm(CharmBase):
         Args:
             event: a :class:`ConfigChangedEvent` to signal that something happened
         """
+        if self.model.relations[OAUTH]:
+            self.oauth.update_client_config(client_config=self._client_config)
+
         self._configure()
         self._configure_replication()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -279,10 +279,11 @@ class GrafanaCharm(CharmBase):
 
     def _on_ingress_ready(self, _) -> None:
         """Once Traefik tells us our external URL, make sure we reconfigure Grafana."""
-        self._configure()
-
         if self.model.relations[OAUTH]:
-            self._set_client_config()
+            relation_id = self.model.relations[OAUTH][0].id
+            self._set_client_config(relation_id)
+
+        self._configure()
 
     def _configure_ingress(self, event: HookEvent) -> None:
         """Set up ingress if a relation is joined, config changed, or a new leader election.
@@ -893,6 +894,28 @@ class GrafanaCharm(CharmBase):
                 }
             )
 
+        if self.model.relations[OAUTH]:
+            relation_id = self.model.relations[OAUTH][0].id
+
+            if self.oauth.is_client_created(relation_id):
+                oauth_provider_info = self.oauth.get_provider_info(relation_id)
+                oauth_client = self.oauth.get_client_credentials(relation_id)
+
+                extra_info.update(
+                    {
+                        "GF_AUTH_GENERIC_OAUTH_ENABLED": "True",
+                        "GF_AUTH_GENERIC_OAUTH_NAME": "Canonical",
+                        "GF_AUTH_GENERIC_OAUTH_CLIENT_ID": oauth_client["client_id"],
+                        "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET": oauth_client["client_secret"],
+                        "GF_AUTH_GENERIC_OAUTH_SCOPES": oauth_provider_info["scope"],
+                        "GF_AUTH_GENERIC_OAUTH_AUTH_URL": oauth_provider_info[
+                            "authorization_endpoint"
+                        ],
+                        "GF_AUTH_GENERIC_OAUTH_TOKEN_URL": oauth_provider_info["token_endpoint"],
+                        "GF_AUTH_GENERIC_OAUTH_API_URL": oauth_provider_info["userinfo_endpoint"],
+                    }
+                )
+
         layer = Layer(
             {
                 "summary": "grafana-k8s layer",
@@ -1325,17 +1348,24 @@ class GrafanaCharm(CharmBase):
             OAUTH_GRANT_TYPES,
         )
 
-    def _set_client_config(self) -> None:
-        self.oauth.update_client_config(self._client_config)
+    def _set_client_config(self, relation_id: int) -> None:
+        self.oauth.update_client_config(client_config=self._client_config, relation_id=relation_id)
 
     def _on_oauth_info_changed(self, event: OAuthInfoChangedEvent) -> None:
         """Event handler for the oauth_info_changed event."""
         if not self.unit.is_leader():
             return
 
-        self._set_client_config()
-        # TODO: Pass provider info as env variables
-        logger.info(f"Oauth provider info: {self.oauth.get_provider_info()}")
+        relation_id = self.model.relations[OAUTH][0].id
+        self._set_client_config(relation_id)
+        logger.info(f"Received oauth provider info: {self.oauth.get_provider_info(relation_id)}")
+
+        if self.oauth.is_client_created(relation_id):
+            self.restart_grafana()
+        else:
+            logger.info("No oauth client info available, deferring the event")
+            event.defer()
+            return
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,7 +30,7 @@ import time
 from io import StringIO
 from pathlib import Path
 from typing import Any, Callable, Dict, cast
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 import subprocess
 
 import yaml

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,7 @@ import string
 import time
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, cast
 from urllib.parse import urljoin, urlparse
 import subprocess
 
@@ -898,8 +898,8 @@ class GrafanaCharm(CharmBase):
             relation_id = self.model.relations[OAUTH][0].id
 
             if self.oauth.is_client_created(relation_id):
-                oauth_provider_info = self.oauth.get_provider_info(relation_id)
-                oauth_client = self.oauth.get_client_credentials(relation_id)
+                oauth_provider_info: dict = cast(dict, self.oauth.get_provider_info(relation_id))
+                oauth_client: dict = cast(dict, self.oauth.get_client_credentials(relation_id))
 
                 extra_info.update(
                     {

--- a/src/charm.py
+++ b/src/charm.py
@@ -1354,7 +1354,7 @@ class GrafanaCharm(CharmBase):
         logger.info(f"Received oauth provider info: {self.oauth.get_provider_info()}")
 
         if not event.client_id or not event.client_secret_id:
-            return None
+            return
         self.restart_grafana()
 
     def _on_oauth_relation_broken(self, event: RelationBrokenEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -1347,11 +1347,12 @@ class GrafanaCharm(CharmBase):
         container.exec(["update-ca-certificates", "--fresh"]).wait()
         subprocess.run(["update-ca-certificates", "--fresh"])
 
+    @property
     def _oauth_client_config(self) -> ClientConfig:
         return ClientConfig(
-            os.path.join(self.external_url, "login/generic_oauth"),
-            OAUTH_SCOPES,
-            OAUTH_GRANT_TYPES,
+            redirect_uri=os.path.join(self.external_url, "login/generic_oauth"),
+            scope=OAUTH_SCOPES,
+            grant_types=OAUTH_GRANT_TYPES,
         )
 
     def _on_oauth_info_changed(self, event: OAuthInfoChangedEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -904,7 +904,7 @@ class GrafanaCharm(CharmBase):
                         "GF_AUTH_GENERIC_OAUTH_NAME": "Canonical",
                         "GF_AUTH_GENERIC_OAUTH_CLIENT_ID": oauth_client.client_id,
                         "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET": oauth_client.client_secret,
-                        "GF_AUTH_GENERIC_OAUTH_SCOPES": oauth_provider_info.scope,
+                        "GF_AUTH_GENERIC_OAUTH_SCOPES": OAUTH_SCOPES,
                         "GF_AUTH_GENERIC_OAUTH_AUTH_URL": oauth_provider_info.authorization_endpoint,
                         "GF_AUTH_GENERIC_OAUTH_TOKEN_URL": oauth_provider_info.token_endpoint,
                         "GF_AUTH_GENERIC_OAUTH_API_URL": oauth_provider_info.userinfo_endpoint,
@@ -1338,7 +1338,7 @@ class GrafanaCharm(CharmBase):
 
     def _client_config(self) -> ClientConfig:
         return ClientConfig(
-            urljoin(self.external_url, "/login/generic_oauth"),
+            os.path.join(self.external_url, "login/generic_oauth"),
             OAUTH_SCOPES,
             OAUTH_GRANT_TYPES,
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -236,7 +236,7 @@ class GrafanaCharm(CharmBase):
         )
 
         # oauth relation
-        self.oauth = OAuthRequirer(self, self._client_config)
+        self.oauth = OAuthRequirer(self, self._oauth_client_config)
 
         # oauth relation observations
         self.framework.observe(self.oauth.on.oauth_info_changed, self._on_oauth_info_changed)
@@ -275,15 +275,14 @@ class GrafanaCharm(CharmBase):
             event: a :class:`ConfigChangedEvent` to signal that something happened
         """
         if self.model.relations[OAUTH]:
-            self.oauth.update_client_config(client_config=self._client_config)
+            self.oauth.update_client_config(client_config=self._oauth_client_config)
 
         self._configure()
         self._configure_replication()
 
     def _on_ingress_ready(self, _) -> None:
         """Once Traefik tells us our external URL, make sure we reconfigure Grafana."""
-        if self.model.relations[OAUTH]:
-            self.oauth.update_client_config(client_config=self._client_config)
+        self.oauth.update_client_config(client_config=self._oauth_client_config)
 
         self._configure()
 
@@ -896,23 +895,23 @@ class GrafanaCharm(CharmBase):
                 }
             )
 
-        if self.model.relations[OAUTH]:
-            if self.oauth.is_client_created():
-                oauth_provider_info = self.oauth.get_provider_info()
-                oauth_client = self.oauth.get_client_credentials()
+        if self.oauth.is_client_created():
+            oauth_provider_info = self.oauth.get_provider_info()
 
-                extra_info.update(
-                    {
-                        "GF_AUTH_GENERIC_OAUTH_ENABLED": "True",
-                        "GF_AUTH_GENERIC_OAUTH_NAME": "Canonical",
-                        "GF_AUTH_GENERIC_OAUTH_CLIENT_ID": oauth_client.client_id,
-                        "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET": oauth_client.client_secret,
-                        "GF_AUTH_GENERIC_OAUTH_SCOPES": OAUTH_SCOPES,
-                        "GF_AUTH_GENERIC_OAUTH_AUTH_URL": oauth_provider_info.authorization_endpoint,
-                        "GF_AUTH_GENERIC_OAUTH_TOKEN_URL": oauth_provider_info.token_endpoint,
-                        "GF_AUTH_GENERIC_OAUTH_API_URL": oauth_provider_info.userinfo_endpoint,
-                    }
-                )
+            extra_info.update(
+                {
+                    "GF_AUTH_GENERIC_OAUTH_ENABLED": "True",
+                    "GF_AUTH_GENERIC_OAUTH_NAME": "Canonical",
+                    "GF_AUTH_GENERIC_OAUTH_CLIENT_ID": cast(str, oauth_provider_info.client_id),
+                    "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET": cast(
+                        str, oauth_provider_info.client_secret
+                    ),
+                    "GF_AUTH_GENERIC_OAUTH_SCOPES": OAUTH_SCOPES,
+                    "GF_AUTH_GENERIC_OAUTH_AUTH_URL": oauth_provider_info.authorization_endpoint,
+                    "GF_AUTH_GENERIC_OAUTH_TOKEN_URL": oauth_provider_info.token_endpoint,
+                    "GF_AUTH_GENERIC_OAUTH_API_URL": oauth_provider_info.userinfo_endpoint,
+                }
+            )
 
         layer = Layer(
             {
@@ -1339,7 +1338,7 @@ class GrafanaCharm(CharmBase):
         container.exec(["update-ca-certificates", "--fresh"]).wait()
         subprocess.run(["update-ca-certificates", "--fresh"])
 
-    def _client_config(self) -> ClientConfig:
+    def _oauth_client_config(self) -> ClientConfig:
         return ClientConfig(
             os.path.join(self.external_url, "login/generic_oauth"),
             OAUTH_SCOPES,
@@ -1351,13 +1350,11 @@ class GrafanaCharm(CharmBase):
         if not self.unit.is_leader():
             return
 
-        self.oauth.update_client_config(client_config=self._client_config)
+        self.oauth.update_client_config(client_config=self._oauth_client_config)
         logger.info(f"Received oauth provider info: {self.oauth.get_provider_info()}")
 
-        if not self.oauth.is_client_created():
-            logger.info("No oauth client info available, deferring the event")
-            event.defer()
-            return
+        if not event.client_id or not event.client_secret_id:
+            return None
         self.restart_grafana()
 
     def _on_oauth_relation_broken(self, event: RelationBrokenEvent) -> None:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 from typing import Tuple
 
+import juju.utils
 import yaml
 from asyncstdlib import functools
 from pytest_operator.plugin import OpsTest
@@ -15,6 +16,14 @@ from urllib.parse import urlparse
 from workload import Grafana
 
 logger = logging.getLogger(__name__)
+
+
+async def block_until_leader_elected(ops_test: OpsTest, app_name: str):
+    async def is_leader_elected():
+        units = ops_test.model.applications[app_name].units
+        return any([await units[i].is_leader_from_status() for i in range(len(units))])
+
+    await juju.utils.block_until_with_coroutine(is_leader_elected)
 
 
 @functools.cache

--- a/tests/integration/test_grafana_dashboard.py
+++ b/tests/integration/test_grafana_dashboard.py
@@ -11,6 +11,7 @@ from helpers import (
     get_dashboard_by_search,
     get_grafana_dashboards,
     oci_image,
+    block_until_leader_elected,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,9 +42,8 @@ async def test_deploy(ops_test, grafana_charm, grafana_tester_charm):
             grafana_tester_charm, resources=tester_resources, application_name=tester_app_name
         ),
     )
-    await ops_test.model.wait_for_idle(
-        apps=[grafana_app_name, tester_app_name], status="active", wait_for_units=1, timeout=300
-    )
+    await block_until_leader_elected(ops_test, grafana_app_name)
+    await ops_test.model.wait_for_idle(status="active", timeout=300, idle_period=60)
 
     await check_grafana_is_ready(ops_test, grafana_app_name, 0)
     initial_dashboards = await get_grafana_dashboards(ops_test, grafana_app_name, 0)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -413,7 +413,9 @@ class TestCharm(unittest.TestCase):
         )
 
         self.assertEqual(services["environment"]["GF_AUTH_GENERIC_OAUTH_ENABLED"], "True")
-        self.assertEqual(services["environment"]["GF_AUTH_GENERIC_OAUTH_NAME"], "Canonical")
+        self.assertEqual(
+            services["environment"]["GF_AUTH_GENERIC_OAUTH_NAME"], "external identity provider"
+        )
         self.assertEqual(
             services["environment"]["GF_AUTH_GENERIC_OAUTH_CLIENT_ID"], "grafana_client_id"
         )


### PR DESCRIPTION
## Issue
Grafana-k8s operator is currently not integrated with IAM stack.
One of its components - Hydra, provides an Oauth relation interface that can be used to integrate charmed applications supporting OIDC/Oauth2 with the IAM bundle and allow to log in with an external identity provider, such as Azure AD.
Grafana is one of the applications that supports both protocols and will therefore be integrated with the IAM bundle as an exemplary third party application in order to create e2e tests.

## Solution
This PR adds integration with hydra-operator through the oauth relation.

## Context
Details of this integration was described in a specification.

Note that a full integration with the IAM stack (including an external identity provider) will be covered in e2e tests in iam-bundle. We currently test on ubuntu 22.04, microk8s 1.26-strict/stable and juju 3.1/stable.

## Testing Instructions
To manually test changes from this PR:
1. Deploy grafana-k8s
2. Deploy postgresql (required dependency for hydra)
`juju deploy postgresql-k8s --channel 14/stable --trust`
3. Deploy hydra, integrate with postgres
`juju deploy hydra --channel edge --trust` (once [this](https://github.com/canonical/hydra-operator/pull/55) PR is merged)
`juju integrate hydra postgresql-k8s`
4. Deploy traefik-public and traefik-admin, relate to hydra:
```
juju deploy traefik-k8s traefik-public --channel edge
juju deploy traefik-k8s traefik-admin --channel edge

juju integrate traefik-public hydra:public-ingress
juju integrate traefik-admin hydra:admin-ingress
```
5. Integrate hydra with grafana:
`juju integrate hydra:oauth grafana-k8s:oauth`
6. If grafana has passed its auth config correctly, `juju show-unit grafana-k8s/0` should return a databag similar to:
```
authorization_endpoint: http://10.64.140.43:80/test3-hydra/oauth2/auth
client_id: 17ea1ab2-6677-48b3-9496-1dc1c70df19b
client_secret_id: secret:<juju secret id>
introspection_endpoint: http://10.64.140.44:80/test3-hydra/admin/oauth2/introspect
issuer_url: http://10.64.140.43:80/test3-hydra
jwks_endpoint: http://10.64.140.43:80/test3-hydra/.well-known/jwks.json
scope: openid profile email phone
token_endpoint: http://10.64.140.43:80/test3-hydra/oauth2/token
userinfo_endpoint: http://10.64.140.43:80/test3-hydra/userinfo
```

If you go to grafana dashboard, you should see a "Log in with Canonical" button, although it will work only if the full [iam bundle](https://github.com/canonical/iam-bundle) is deployed. If you log in with the default admin user, you will be able to see the oauth provider config reflected in the settings.

The flow was tested on our end with Azure AD as the identity provider.
To test the e2e flow on your end, you need to have an external identity provider with kratos registered as an app and provide its details to kratos-external-idp operator.
Note that if you are using self-signed certificates, you need to deploy grafana with an additional variable:
`GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE=True`, otherwise it will not trust hydra's certificate.


## Release Notes
Added integration with oauth
