### PR TITLE
use ruff instead of flake8

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_auth.py
+++ b/lib/charms/grafana_k8s/v0/grafana_auth.py
@@ -89,7 +89,7 @@ class ExampleRequirerCharm(CharmBase):
 
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from jsonschema import validate  # type: ignore[import]
 from ops.charm import (
@@ -244,10 +244,9 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
+    if isinstance(obj, StoredDict):
         return {k: _type_convert_stored(obj[k]) for k in obj.keys()}
-    else:
-        return obj
+    return obj
 
 
 class UrlsAvailableEvent(EventBase):

--- a/lib/charms/grafana_k8s/v0/grafana_auth.py
+++ b/lib/charms/grafana_k8s/v0/grafana_auth.py
@@ -89,7 +89,7 @@ class ExampleRequirerCharm(CharmBase):
 
 import json
 import logging
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from jsonschema import validate  # type: ignore[import]
 from ops.charm import (
@@ -117,7 +117,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 AUTH_PROXY_PROVIDER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema",
@@ -292,7 +292,7 @@ class AuthProvider(Object):
         refresh_event: Optional[BoundEvent] = None,
     ):
         super().__init__(charm, relation_name)
-        self._auth_config = {}  # type: Dict[str, Dict[str, Any]]
+        self._auth_config: Dict[str, Dict[str, Any]] = {}
         self._charm = charm
         self._relation_name = relation_name
         if not refresh_event:

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 29
+LIBPATCH = 30
 
 logger = logging.getLogger(__name__)
 
@@ -1505,7 +1505,7 @@ class GrafanaDashboardConsumer(Object):
             stored_dashboards[relation.id] = stored_data
             self.set_peer_data("dashboards", stored_dashboards)
             return True
-        return None
+        return None  # type: ignore
 
     def _manage_dashboard_uid(self, dashboard: str, template: dict) -> str:
         """Add an uid to the dashboard if it is not present."""

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -582,7 +582,7 @@ def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> st
 
     # If no existing template variables exist, just insert our own
     if "templating" not in dict_content:
-        dict_content["templating"] = {"list": [d for d in template_dropdowns]}  # type: ignore
+        dict_content["templating"] = {"list": list(template_dropdowns)}  # type: ignore
     else:
         # Otherwise, set a flag so we can go back later
         existing_templates = True
@@ -830,18 +830,18 @@ def _modify_panel(panel: dict, topology: dict, transformer: "CosTool") -> dict:
 
         if "datasource" not in panel.keys():
             continue
-        else:
-            if type(panel["datasource"]) == str:
-                if panel["datasource"] not in known_datasources:
-                    continue
-                querytype = known_datasources[panel["datasource"]]
-            elif type(panel["datasource"]) == dict:
-                if panel["datasource"]["uid"] not in known_datasources:
-                    continue
-                querytype = known_datasources[panel["datasource"]["uid"]]
-            else:
-                logger.error("Unknown datasource format: skipping")
+
+        if type(panel["datasource"]) == str:
+            if panel["datasource"] not in known_datasources:
                 continue
+            querytype = known_datasources[panel["datasource"]]
+        elif type(panel["datasource"]) == dict:
+            if panel["datasource"]["uid"] not in known_datasources:
+                continue
+            querytype = known_datasources[panel["datasource"]["uid"]]
+        else:
+            logger.error("Unknown datasource format: skipping")
+            continue
 
         # Capture all values inside `[]` into a list which we'll iterate over later to
         # put them back in-order. Then apply the regex again and replace everything with
@@ -901,13 +901,12 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
+    if isinstance(obj, StoredDict):
         rdict = {}  # type: Dict[Any, Any]
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
-    else:
-        return obj
+    return obj
 
 
 class GrafanaDashboardsChanged(EventBase):
@@ -1251,7 +1250,7 @@ class GrafanaDashboardProvider(Object):
     @property
     def dashboard_templates(self) -> List:
         """Return a list of the known dashboard templates."""
-        return [v for v in self._stored.dashboard_templates.values()]  # type: ignore
+        return list(self._stored.dashboard_templates.values())  # type: ignore
 
 
 class GrafanaDashboardConsumer(Object):
@@ -1305,7 +1304,7 @@ class GrafanaDashboardConsumer(Object):
         self._relation_name = relation_name
         self._tranformer = CosTool(self._charm)
 
-        self._stored.set_default(dashboards=dict())  # type: ignore
+        self._stored.set_default(dashboards={})  # type: ignore
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
@@ -1495,19 +1494,18 @@ class GrafanaDashboardConsumer(Object):
 
             # Dropping dashboards for a relation needs to be signalled
             return True
-        else:
-            stored_data = rendered_dashboards
-            currently_stored_data = self._get_stored_dashboards(relation.id)
 
-            coerced_data = (
-                _type_convert_stored(currently_stored_data) if currently_stored_data else {}
-            )
+        stored_data = rendered_dashboards
+        currently_stored_data = self._get_stored_dashboards(relation.id)
 
-            if not coerced_data == stored_data:
-                stored_dashboards = self.get_peer_data("dashboards")
-                stored_dashboards[relation.id] = stored_data
-                self.set_peer_data("dashboards", stored_dashboards)
-                return True
+        coerced_data = _type_convert_stored(currently_stored_data) if currently_stored_data else {}
+
+        if not coerced_data == stored_data:
+            stored_dashboards = self.get_peer_data("dashboards")
+            stored_dashboards[relation.id] = stored_data
+            self.set_peer_data("dashboards", stored_dashboards)
+            return True
+        return None
 
     def _manage_dashboard_uid(self, dashboard: str, template: dict) -> str:
         """Add an uid to the dashboard if it is not present."""

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -160,7 +160,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -173,13 +173,12 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
+    if isinstance(obj, StoredDict):
         rdict = {}
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
-    else:
-        return obj
+    return obj
 
 
 class RelationNotFoundError(Exception):
@@ -499,7 +498,7 @@ class GrafanaSourceConsumer(Object):
         # We're stuck with this forever now so upgrades work, or until such point as we can
         # break compatibility
         self._stored.set_default(  # type: ignore
-            sources=dict(),
+            sources={},
             sources_to_delete=set(),
         )
 
@@ -546,7 +545,7 @@ class GrafanaSourceConsumer(Object):
         """Generate configuration from data stored in relation data by providers."""
         source_data = json.loads(rel.data[rel.app].get("grafana_source_data", "{}"))  # type: ignore
         if not source_data:
-            return
+            return None
 
         data = []
 
@@ -700,7 +699,7 @@ class GrafanaSourceConsumer(Object):
         sources = []
         stored_sources = self.get_peer_data("sources")
         for source in stored_sources.values():
-            sources.extend([host for host in _type_convert_stored(source)])
+            sources.extend(list(_type_convert_stored(source)))
 
         return sources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 1
-
 [tool.mypy]
 pretty = true
 mypy_path = "./src:./lib:./tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,25 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "W505", "E501", "D107", "E203"]
+ignore = ["W505", "E501", "D107", "C901", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 1
 
 [tool.mypy]
 pretty = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -331,7 +331,7 @@ class GrafanaCharm(CharmBase):
         scrape_related_apps = [rel.app for rel in self.model.relations["metrics-endpoint"]]
 
         has_relation = any(
-            [source for source in source_related_apps if source in scrape_related_apps]
+            source for source in source_related_apps if source in scrape_related_apps
         )
 
         dashboards_dir_path = os.path.join(PROVISIONING_PATH, "dashboards")
@@ -1078,8 +1078,7 @@ class GrafanaCharm(CharmBase):
         if self.ingress.external_host:
             baseurl = "http://{}".format(self.ingress.external_host)
             return "{}/{}".format(baseurl, "{}-{}".format(self.model.name, self.model.app.name))
-        else:
-            return "http://{}:{}".format(socket.getfqdn(), PORT)
+        return "http://{}:{}".format(socket.getfqdn(), PORT)
 
     @property
     def _ingress_config(self) -> dict:

--- a/src/grafana_server.py
+++ b/src/grafana_server.py
@@ -76,5 +76,4 @@ class Grafana:
         info = json.loads(response.data.decode("utf-8"))
         if info["database"] == "ok":
             return info
-        else:
-            return {}
+        return {}

--- a/src/kubernetes_service.py
+++ b/src/kubernetes_service.py
@@ -50,8 +50,7 @@ class K8sServicePatch:
                 raise PatchFailed(
                     "No permission to read cluster role. " "Run `juju trust` on this application."
                 ) from e
-            else:
-                raise e
+            raise e
 
     @staticmethod
     def _k8s_service(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,7 +10,6 @@ from typing import Tuple
 
 import yaml
 from asyncstdlib import functools
-from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
 from workload import Grafana
 
@@ -151,7 +150,9 @@ async def get_grafana_dashboards(ops_test: OpsTest, app_name: str, unit_num: int
     look through a query and fetch them.
 
     Args:
+        ops_test: pytest-operator plugin
         app_name: string name of Grafana application
+        unit_num: integer number of a Juju unit
 
     Returns:
         a list of dashboards
@@ -173,7 +174,9 @@ async def get_dashboard_by_search(
     look through a query and fetch them.
 
     Args:
+        ops_test: pytest-operator plugin
         app_name: string name of Grafana application
+        unit_num: integer number of a Juju unit
         query_string: the search string to use
 
     Returns:

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -46,7 +46,7 @@ DASHBOARD_DATA = {
 DASHBOARD_RENDERED = json.dumps(
     {
         "panels": {"data": "label_values(up, juju_unit)"},
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -54,7 +54,7 @@ DASHBOARD_RENDERED = json.dumps(
 DASHBOARD_RENDERED_NO_DROPDOWNS = json.dumps(
     {
         "panels": {"data": "label_values(up, juju_unit)"},
-        "templating": {"list": [d for d in DATASOURCE_TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(DATASOURCE_TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -80,7 +80,7 @@ VARIABLE_DASHBOARD_RENDERED = json.dumps(
         "panels": [
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -121,7 +121,7 @@ ROW_ONLY_DASHBOARD_RENDERED = json.dumps(
                 ],
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -150,7 +150,7 @@ INPUT_DASHBOARD_RENDERED = json.dumps(
         "panels": [
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -175,7 +175,7 @@ NULL_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
             {"data": "Row separator", "datasource": None},
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -220,7 +220,7 @@ BUILTIN_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
                 "title": "foo",
             }
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -270,7 +270,7 @@ EXISTING_VARIABLE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
         ],
         "templating": {
-            "list": [d for d in reversed(TEMPLATE_DROPDOWNS)]
+            "list": list(reversed(TEMPLATE_DROPDOWNS))
             + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
         },
     }
@@ -322,7 +322,7 @@ EXISTING_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
         ],
         "templating": {
-            "list": [d for d in reversed(TEMPLATE_DROPDOWNS)]
+            "list": list(reversed(TEMPLATE_DROPDOWNS))
             + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
         },
     }
@@ -374,7 +374,7 @@ EXISTING_LOKI_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
         ],
         "templating": {
-            "list": [d for d in reversed(TEMPLATE_DROPDOWNS)]
+            "list": list(reversed(TEMPLATE_DROPDOWNS))
             + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
         },
     }
@@ -405,7 +405,7 @@ DICT_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
                 },
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -591,7 +591,7 @@ class TestDashboardConsumer(unittest.TestCase):
                 },
             )
             self.assertTrue(
-                any(["Invalid JSON in Grafana dashboard: file:tester" in msg for msg in cm.output])
+                any("Invalid JSON in Grafana dashboard: file:tester" in msg for msg in cm.output)
             )
 
     def test_consumer_templates_datasource(self):

--- a/tests/unit/test_dashboard_transform.py
+++ b/tests/unit/test_dashboard_transform.py
@@ -65,7 +65,7 @@ DASHBOARD_RENDERED = json.dumps(
                 ],
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -88,7 +88,7 @@ DASHBOARD_RENDERED_NO_TOPOLOGY = json.dumps(
                 ],
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -132,7 +132,7 @@ LOKI_DASHBOARD_RENDERED = json.dumps(
                 ],
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -187,7 +187,7 @@ DASHBOARD_RENDERED_WITH_NEGATIVE = json.dumps(
                 "datasource": "${prometheusds}",
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -231,7 +231,7 @@ DASHBOARD_RENDERED_WITH_RANGES = json.dumps(
                 "datasource": "${prometheusds}",
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 
@@ -275,7 +275,7 @@ DASHBOARD_RENDERED_WITH_OFFSETS = json.dumps(
                 "datasource": "${prometheusds}",
             },
         ],
-        "templating": {"list": [d for d in TEMPLATE_DROPDOWNS]},
+        "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,29 +31,21 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
+    ruff
     codespell
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being three new rules being ignored (which weren't checked before anyway): 
* `N818: Exception name should be named with an Error suffix`, which I excluded due to the big refactoring required for it;
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability;
* `C901: Function is too complex`, as it was triggering pretty much everywhere.