### PR TITLE
Lock Pyright version to fix CI flakiness on canonical/operator

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,7 @@ import string
 import time
 from io import StringIO
 from pathlib import Path
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List, Tuple
 from urllib.parse import ParseResult, urlparse
 
 import yaml
@@ -573,7 +573,7 @@ class GrafanaCharm(CharmBase):
     def _patch_k8s_service(self):
         """Fix the Kubernetes service that was setup by Juju with correct port numbers."""
         if self.unit.is_leader() and not self._stored.k8s_service_patched:  # type: ignore[truthy-function]
-            service_ports = [
+            service_ports: List[Tuple[str, int, int]] = [
                 (self.app.name, PORT, PORT),
             ]
             try:

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    pyright
+    pyright==1.1.316
     charm: -r{toxinidir}/requirements.txt
     lib: 
       ops 


### PR DESCRIPTION
Fix type checking issue with `service_ports`. Also pin Pyright version to avoid it breaking CI in future.

This worked in Pyright 1.1.314, but not in 1.1.315 or 1.1.316.

The type of service_ports is `List[Tuple[str, Literal[3000], Literal[3000]]]`, which doesn't type check as `List[Tuple[str, int, int]]` -- which is very unintuitive, but oh well.

I believe this is by design, see https://github.com/microsoft/pyright/issues/5366 and https://microsoft.github.io/pyright/#/type-inference?id=tuple-expressions

The Pyright fixes were probably one of https://github.com/microsoft/pyright/issues/5321 or https://github.com/microsoft/pyright/pull/5323

See https://github.com/canonical/operator/actions/runs/5384117730/jobs/9771655581?pr=957

```
Installing collected packages: lightkube-models, websocket-client, urllib3, sniffio, six, pyyaml, pyrsistent, pyasn1, oauthlib, nodeenv, markupsafe, idna, h11, exceptiongroup, charset-normalizer, certifi, cachetools, attrs, rsa, requests, python-dateutil, pyright, pyasn1-modules, ops, jsonschema, jinja2, anyio, requests-oauthlib, httpcore, google-auth, kubernetes, httpx, lightkube
Successfully installed anyio-3.7.0 attrs-23.1.0 cachetools-5.3.1 certifi-2023.5.7 charset-normalizer-3.1.0 exceptiongroup-1.1.1 google-auth-2.21.0 h11-0.14.0 httpcore-0.17.2 httpx-0.24.1 idna-3.4 jinja2-2.11.3 jsonschema-4.17.3 kubernetes-26.1.0 lightkube-0.13.0 lightkube-models-1.27.1.4 markupsafe-2.0.1 nodeenv-1.8.0 oauthlib-3.2.2 ops-2.3.0+12.g8ce1a65 pyasn1-0.5.0 pyasn1-modules-0.3.0 pyright-1.1.316 pyrsistent-0.19.3 python-dateutil-2.8.2 pyyaml-6.0 requests-2.31.0 requests-oauthlib-1.3.1 rsa-4.9 six-1.16.0 sniffio-1.3.0 urllib3-1.26.16 websocket-client-1.6.1
static-charm: 7676 I exit 0 (7.23 seconds) /home/runner/work/operator/operator> python -I -m pip install jinja2 ops pyright -r /home/runner/work/operator/operator/requirements.txt pid=2498 [tox/execute/api.py:279]
static-charm: 7677 W freeze> python -m pip freeze --all [tox/tox_env/api.py:427]
static-charm: 8136 I exit 0 (0.46 seconds) /home/runner/work/operator/operator> python -m pip freeze --all pid=2589 [tox/execute/api.py:279]
static-charm: 8136 W anyio==3.7.0,attrs==23.1.0,cachetools==5.3.1,certifi==2023.5.7,charset-normalizer==3.1.0,exceptiongroup==1.1.1,google-auth==2.21.0,h11==0.14.0,httpcore==0.17.2,httpx==0.24.1,idna==3.4,Jinja2==2.11.3,jsonschema==4.17.3,kubernetes==26.1.0,lightkube==0.13.0,lightkube-models==1.27.1.4,MarkupSafe==2.0.1,nodeenv==1.8.0,oauthlib==3.2.2,ops @ git+https://github.com/canonical/operator@8ce1a6516835c7f12207f676de00d67d700f6340,pip==23.1.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pyright==1.1.316,pyrsistent==0.19.3,python-dateutil==2.8.2,PyYAML==6.0,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,setuptools==67.8.0,six==1.16.0,sniffio==1.3.0,urllib3==1.26.16,websocket-client==1.6.1,wheel==0.40.0 [tox/tox_env/python/api.py:236]
static-charm: 8137 W commands[0]> pyright /home/runner/work/operator/operator/src [tox/tox_env/api.py:427]

added 1 package, and audited 2 packages in 3s

found 0 vulnerabilities
npm notice 
npm notice New minor version of npm available! 9.5.1 -> 9.7.2
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.7.2>
npm notice Run `npm install -g npm@9.7.2` to update!
npm notice 
/home/runner/work/operator/operator/src/charm.py
  /home/runner/work/operator/operator/src/charm.py:580:58 - error: Argument of type "list[tuple[str, Literal[3000], Literal[3000]]]" cannot be assigned to parameter "service_ports" of type "List[Tuple[str, int, int]]" in function "set_ports"
    "list[tuple[str, Literal[3000], Literal[3000]]]" is incompatible with "List[Tuple[str, int, int]]"
      TypeVar "_T@list" is invariant
        "tuple[str, Literal[3000], Literal[3000]]" is incompatible with "Tuple[str, int, int]"
          Tuple entry 2 is incorrect type
            "Literal[3000]" is incompatible with "int" (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations 
static-charm: 18257 C exit 1 (10.12 seconds) /home/runner/work/operator/operator> pyright /home/runner/work/operator/operator/src pid=2594 [tox/execute/api.py:279]
  static-charm: FAIL code 1 (18.05=setup[7.93]+cmd[10.12] seconds)
```