### PR TITLE
Add insecureSkipVerify support for grafana_source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jinja2 < 3
 kubernetes
 lightkube >= 0.11
 markupsafe == 2.0.1
-git+https://github.com/canonical/operator#egg=ops
+ops
 pyyaml
 urllib3
 jsonschema

--- a/src/charm.py
+++ b/src/charm.py
@@ -1290,4 +1290,4 @@ class GrafanaCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(GrafanaCharm)
+    main(GrafanaCharm, use_juju_for_storage=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -1290,4 +1290,4 @@ class GrafanaCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(GrafanaCharm, use_juju_for_storage=True)
+    main(GrafanaCharm)

--- a/tests/unit/test_source_provider.py
+++ b/tests/unit/test_source_provider.py
@@ -90,7 +90,7 @@ class TestSourceProvider(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
         self.assertIn("grafana_source_host", data)
-        self.assertEqual(data["grafana_source_host"], "fqdn1:9090")
+        self.assertEqual(data["grafana_source_host"], "http://fqdn1:9090")
 
     @patch("socket.getfqdn", new=lambda *args: "fqdn2")
     def test_provider_unit_sets_address_on_relation_joined(self):
@@ -98,7 +98,7 @@ class TestSourceProvider(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
         self.assertIn("grafana_source_host", data)
-        self.assertEqual(data["grafana_source_host"], "fqdn2:9090")
+        self.assertEqual(data["grafana_source_host"], "http://fqdn2:9090")
 
 
 class TestAlertManagerProvider(unittest.TestCase):
@@ -138,7 +138,7 @@ class TestMimirProvider(unittest.TestCase):
         self.assertIn("model_uuid", scrape_data)
         self.assertIn("application", scrape_data)
         host_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
-        self.assertEqual(host_data["grafana_source_host"], "mimir:9009/prometheus")
+        self.assertEqual(host_data["grafana_source_host"], "http://mimir:9009/prometheus")
 
 
 class ProviderCharmWithIngress(CharmBase):


### PR DESCRIPTION
## Issue
HTTPS datasources do not work when grafana isn't related to a CA.


## Solution
Add `insecureSkipVerify`.

Drive-by fixes:
- Loop over relations to avoid `ops.model.TooManyRelatedAppsError: Too many remote applications on grafana-source (2 > 1)` in `File "/var/lib/juju/agents/unit-prom-0/charm/lib/charms/grafana_k8s/v0/grafana_source.py", line 416, in update_source`.
- Add missing `http://` (we communicate URLs, not hostnames, over reldata).


## Context
- This PR builds upon https://github.com/canonical/grafana-k8s-operator/pull/226.
- This PR complements https://github.com/canonical/loki-k8s-operator/pull/289 and similar.


## Testing Instructions
1. Deploy grafana, prometheus, ca.
2. In the grafana UI, click "test" for the prometheus datasource for each of the following relation combos:
  - prometheus-grafana
  - ca-prometheus-grafana
  - prometheus-grafana-ca
  - ca-prometheus-grafana-ca


## Release Notes
Add insecureSkipVerify support for grafana_source.
