### PR TITLE
Include dashboard url in get-admin-password action response

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,5 +1,5 @@
 get-admin-password:
   description: |
-    Get the initial admin password for the Grafana web interface. This is generated at charm
-    deployment time. If the password has been changed, a notice of that fact will be returned by
-    this action instead.
+    Get the dashboard url and initial admin password for the Grafana web interface. Initial
+    admin password is generated at charm deployment time. If the password has been changed,
+    a notice of that fact will be returned by this action instead.

--- a/src/charm.py
+++ b/src/charm.py
@@ -1095,7 +1095,7 @@ class GrafanaCharm(CharmBase):
         return datasources_string
 
     def _on_get_admin_password(self, event: ActionEvent) -> None:
-        """Returns the password for the admin user as an action response."""
+        """Returns the grafana url and password for the admin user as an action response."""
         if not self.grafana_service.is_ready:
             event.fail("Grafana is not reachable yet. Please try again in a few minutes")
             return
@@ -1110,10 +1110,15 @@ class GrafanaCharm(CharmBase):
 
         if pw_changed:
             event.set_results(
-                {"admin-password": "Admin password has been changed by an administrator"}
+                {
+                    "url": self.external_url,
+                    "admin-password": "Admin password has been changed by an administrator",
+                }
             )
         else:
-            event.set_results({"admin-password": self._get_admin_password()})
+            event.set_results(
+                {"url": self.external_url, "admin-password": self._get_admin_password()}
+            )
 
     def _generate_admin_password(self) -> None:
         """Generate the admin password if it's not already in stored state, and store it there."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -232,7 +232,10 @@ class TestCharm(unittest.TestCase):
         event = MagicMock()
         self.harness.charm._on_get_admin_password(event)
         event.set_results.assert_called_with(
-            {"admin-password": "Admin password has been changed by an administrator"}
+            {
+                "url": "http://grafana-k8s-0.testmodel.svc.cluster.local:3000",
+                "admin-password": "Admin password has been changed by an administrator",
+            }
         )
 
     def test_datasource_timeout_value_overrides_config_if_larger(self):


### PR DESCRIPTION
Add grafana dashboard url to response of action get-admin-password. 

Closes #92

## Issue
<!-- What issue is this PR trying to solve? -->
Currently the action get-admin-password returns only admin password but not the dashboard url.

## Solution
<!-- A summary of the solution addressing the above issue -->
PR updates the response of action get-admin-password to include grafana dashboard url.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
Include grafana dashboard url in get-admin-password action response