### PR TITLE
add proxy config from env variables

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 32
+LIBPATCH = 33
 
 logger = logging.getLogger(__name__)
 
@@ -665,14 +665,14 @@ def _template_panels(
             continue
         if not existing_templates:
             datasource = panel.get("datasource")
-            if type(datasource) == str:
+            if isinstance(datasource, str):
                 if "loki" in datasource:
                     panel["datasource"] = "${lokids}"
                 elif "grafana" in datasource:
                     continue
                 else:
                     panel["datasource"] = "${prometheusds}"
-            elif type(datasource) == dict:
+            elif isinstance(datasource, dict):
                 # In dashboards exported by Grafana 9, datasource type is dict
                 dstype = datasource.get("type", "")
                 if dstype == "loki":
@@ -686,7 +686,7 @@ def _template_panels(
                 logger.error("Unknown datasource format: skipping")
                 continue
         else:
-            if type(panel["datasource"]) == str:
+            if isinstance(panel["datasource"], str):
                 if panel["datasource"].lower() in replacements.values():
                     # Already a known template variable
                     continue
@@ -701,7 +701,7 @@ def _template_panels(
                 if replacement:
                     used_replacements.append(ds)
                 panel["datasource"] = replacement or panel["datasource"]
-            elif type(panel["datasource"]) == dict:
+            elif isinstance(panel["datasource"], dict):
                 dstype = panel["datasource"].get("type", "")
                 if panel["datasource"].get("uid", "").lower() in replacements.values():
                     # Already a known template variable
@@ -831,7 +831,7 @@ def _modify_panel(panel: dict, topology: dict, transformer: "CosTool") -> dict:
         if "datasource" not in panel.keys():
             continue
 
-        if type(panel["datasource"]) == str:
+        if isinstance(panel["datasource"], str):
             if panel["datasource"] not in known_datasources:
                 continue
             querytype = known_datasources[panel["datasource"]]

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class CertChanged(EventBase):
@@ -101,7 +101,7 @@ class CertHandler(Object):
             peer_relation_name: Must match metadata.yaml.
             certificates_relation_name: Must match metadata.yaml.
             cert_subject: Custom subject. Name collisions are under the caller's responsibility.
-            extra_sans_dns: Any additional DNS names apart from FQDN.
+            extra_sans_dns: DNS names. If none are given, use FQDN.
         """
         super().__init__(charm, key)
 
@@ -109,8 +109,8 @@ class CertHandler(Object):
         self.cert_subject = cert_subject or charm.unit.name
         self.cert_subject = charm.unit.name if not cert_subject else cert_subject
 
-        # Auto-include the fqdn and drop empty/duplicate sans
-        self.sans_dns = list(set(filter(None, (extra_sans_dns or []) + [socket.getfqdn()])))
+        # Use fqdn only if no SANs were given, and drop empty/duplicate SANs
+        self.sans_dns = list(set(filter(None, (extra_sans_dns or [socket.getfqdn()]))))
 
         self.peer_relation_name = peer_relation_name
         self.certificates_relation_name = certificates_relation_name

--- a/src/charm.py
+++ b/src/charm.py
@@ -891,9 +891,9 @@ class GrafanaCharm(CharmBase):
         # Juju Proxy settings
         extra_info.update(
             {
-                "https_proxy": os.environ['JUJU_CHARM_HTTPS_PROXY'],
-                "http_proxy": os.environ['JUJU_CHARM_HTTP_PROXY'],
-                "no_proxy": os.environ['JUJU_CHARM_NO_PROXY'],
+                "https_proxy": os.environ["JUJU_CHARM_HTTPS_PROXY"],
+                "http_proxy": os.environ["JUJU_CHARM_HTTP_PROXY"],
+                "no_proxy": os.environ["JUJU_CHARM_NO_PROXY"],
             }
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -891,9 +891,15 @@ class GrafanaCharm(CharmBase):
         # Juju Proxy settings
         extra_info.update(
             {
-                "https_proxy": os.environ["JUJU_CHARM_HTTPS_PROXY"],
-                "http_proxy": os.environ["JUJU_CHARM_HTTP_PROXY"],
-                "no_proxy": os.environ["JUJU_CHARM_NO_PROXY"],
+                "https_proxy": os.environ["JUJU_CHARM_HTTPS_PROXY"]
+                if "JUJU_CHARM_HTTPS_PROXY" in os.environ
+                else "",
+                "http_proxy": os.environ["JUJU_CHARM_HTTP_PROXY"]
+                if "JUJU_CHARM_HTTP_PROXY" in os.environ
+                else "",
+                "no_proxy": os.environ["JUJU_CHARM_NO_PROXY"]
+                if "JUJU_CHARM_NO_PROXY" in os.environ
+                else "",
             }
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -888,6 +888,15 @@ class GrafanaCharm(CharmBase):
             "GF_DATABASE_TYPE": "sqlite3",
         }
 
+        # Juju Proxy settings
+        extra_info.update(
+            {
+                "https_proxy": os.environ['JUJU_CHARM_HTTPS_PROXY'],
+                "http_proxy": os.environ['JUJU_CHARM_HTTP_PROXY'],
+                "no_proxy": os.environ['JUJU_CHARM_NO_PROXY'],
+            }
+        )
+
         grafana_path = self.external_url
         if self._auth_env_vars:
             extra_info.update(self._auth_env_vars)


### PR DESCRIPTION
## Issue
Closes #240.


## Solution
Grafana should honor the proxy settings set in the Juju model, by simply extracting that information from the [environment context](https://juju.is/docs/sdk/charm-environment-variables) and setting the appropriate environment variables in the pebble layer.

## Additional Changes
The changes in `grafana_dashboard` are to satisfy the linter, and cert-handler comes from `fetch-lib` :)