### PR TITLE
Fix `stripPrefix`

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 35
+LIBPATCH = 34
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 34
+LIBPATCH = 35
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 41
+LIBPATCH = 42
 
 PYDEPS = ["cosl"]
 
@@ -604,12 +604,12 @@ class PrometheusConfig:
         return {
             "alertmanagers": [
                 {
+                    # For https we still do not render a `tls_config` section because
+                    # certs are expected to be made available by the charm via the
+                    # `update-ca-certificates` mechanism.
                     "scheme": scheme,
                     "path_prefix": path_prefix,
                     "static_configs": [{"targets": netlocs}],
-                    # FIXME figure out how to get alertmanager's ca_file into here
-                    #  Without this, prom errors: "x509: certificate signed by unknown authority"
-                    "tls_config": {"insecure_skip_verify": True},
                 }
                 for (scheme, path_prefix), netlocs in paths.items()
             ]
@@ -1176,16 +1176,8 @@ class MetricsEndpointConsumer(Object):
             scrape_configs, hosts, topology
         )
 
-        # If scheme is https but no ca section present, then auto add "insecure_skip_verify",
-        # otherwise scraping errors out with "x509: certificate signed by unknown authority".
-        # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config
-        for scrape_config in scrape_configs:
-            tls_config = scrape_config.get("tls_config", {})
-            ca_present = "ca" in tls_config or "ca_file" in tls_config
-            if scrape_config.get("scheme") == "https" and not ca_present:
-                tls_config["insecure_skip_verify"] = True
-                scrape_config["tls_config"] = tls_config
-
+        # For https scrape targets we still do not render a `tls_config` section because certs
+        # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
         return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -18,13 +18,6 @@ provide a scrape target for Prometheus.
 Source code can be found on GitHub at:
  https://github.com/canonical/prometheus-k8s-operator/tree/main/lib/charms/prometheus_k8s
 
-## Dependencies
-
-Using this library requires you to fetch the juju_topology library from
-[observability-libs](https://charmhub.io/observability-libs/libraries/juju_topology).
-
-`charmcraft fetch-lib charms.observability_libs.v0.juju_topology`
-
 ## Provider Library Usage
 
 This Prometheus charm interacts with its scrape targets using its
@@ -346,7 +339,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl import JujuTopology
+from cosl.rules import AlertRules
 from ops.charm import CharmBase, RelationRole
 from ops.framework import (
     BoundEvent,
@@ -368,7 +362,9 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 41
+
+PYDEPS = ["cosl"]
 
 logger = logging.getLogger(__name__)
 
@@ -836,206 +832,6 @@ def _is_single_alert_rule_format(rules_dict: dict) -> bool:
     return set(rules_dict) >= {"alert", "expr"}
 
 
-class AlertRules:
-    """Utility class for amalgamating prometheus alert rule files and injecting juju topology.
-
-    An `AlertRules` object supports aggregating alert rules from files and directories in both
-    official and single rule file formats using the `add_path()` method. All the alert rules
-    read are annotated with Juju topology labels and amalgamated into a single data structure
-    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
-    easily dumped into JSON format and exchanged over relation data. The dictionary can also
-    be dumped into YAML format and written directly into an alert rules file that is read by
-    Prometheus. Note that multiple `AlertRules` objects must not be written into the same file,
-    since Prometheus allows only a single list of alert rule groups per alert rules file.
-
-    The official Prometheus format is a YAML file conforming to the Prometheus documentation
-    (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
-    The custom single rule format is a subsection of the official YAML, having a single alert
-    rule, effectively "one alert per file".
-    """
-
-    # This class uses the following terminology for the various parts of a rule file:
-    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
-    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
-    #   of dictionaries that have the "name" and "rules" keys.
-    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
-    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
-    #   the "alert" and "expr" keys.
-    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
-
-    def __init__(self, topology: Optional[JujuTopology] = None):
-        """Build and alert rule object.
-
-        Args:
-            topology: an optional `JujuTopology` instance that is used to annotate all alert rules.
-        """
-        self.topology = topology
-        self.tool = CosTool(None)
-        self.alert_groups = []  # type: List[dict]
-
-    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
-        """Read a rules file from path, injecting juju topology.
-
-        Args:
-            root_path: full path to the root rules folder (used only for generating group name)
-            file_path: full path to a *.rule file.
-
-        Returns:
-            A list of dictionaries representing the rules file, if file is valid (the structure is
-            formed by `yaml.safe_load` of the file); an empty list otherwise.
-        """
-        with file_path.open() as rf:
-            # Load a list of rules from file then add labels and filters
-            try:
-                rule_file = yaml.safe_load(rf)
-
-            except Exception as e:
-                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
-                return []
-
-            if not rule_file:
-                logger.warning("Empty rules file: %s", file_path.name)
-                return []
-            if not isinstance(rule_file, dict):
-                logger.error("Invalid rules file (must be a dict): %s", file_path.name)
-                return []
-            if _is_official_alert_rule_format(rule_file):
-                alert_groups = rule_file["groups"]
-            elif _is_single_alert_rule_format(rule_file):
-                # convert to list of alert groups
-                # group name is made up from the file name
-                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
-            else:
-                # invalid/unsupported
-                logger.error("Invalid rules file: %s", file_path.name)
-                return []
-
-            # update rules with additional metadata
-            for alert_group in alert_groups:
-                # update group name with topology and sub-path
-                alert_group["name"] = self._group_name(
-                    str(root_path),
-                    str(file_path),
-                    alert_group["name"],
-                )
-
-                # add "juju_" topology labels
-                for alert_rule in alert_group["rules"]:
-                    if "labels" not in alert_rule:
-                        alert_rule["labels"] = {}
-
-                    if self.topology:
-                        alert_rule["labels"].update(self.topology.label_matcher_dict)
-                        # insert juju topology filters into a prometheus alert rule
-                        alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%,?", "", alert_rule["expr"]),
-                            self.topology.label_matcher_dict,
-                        )
-
-            return alert_groups
-
-    def _group_name(self, root_path: str, file_path: str, group_name: str) -> str:
-        """Generate group name from path and topology.
-
-        The group name is made up of the relative path between the root dir_path, the file path,
-        and topology identifier.
-
-        Args:
-            root_path: path to the root rules dir.
-            file_path: path to rule file.
-            group_name: original group name to keep as part of the new augmented group name
-
-        Returns:
-            New group name, augmented by juju topology and relative path.
-        """
-        rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
-        rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
-
-        # Generate group name:
-        #  - name, from juju topology
-        #  - suffix, from the relative path of the rule file;
-        group_name_parts = [self.topology.identifier] if self.topology else []
-        group_name_parts.extend([rel_path, group_name, "alerts"])
-        # filter to remove empty strings
-        return "_".join(filter(None, group_name_parts))
-
-    @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
-        """Helper function for getting all files in a directory that have a matching suffix.
-
-        Args:
-            dir_path: path to the directory to glob from.
-            suffixes: list of suffixes to include in the glob (items should begin with a period).
-            recursive: a flag indicating whether a glob is recursive (nested) or not.
-
-        Returns:
-            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
-        """
-        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
-        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
-
-    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
-        """Read all rule files in a directory.
-
-        All rules from files for the same directory are loaded into a single
-        group. The generated name of this group includes juju topology.
-        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
-
-        Args:
-            dir_path: directory containing *.rule files (alert rules without groups).
-            recursive: flag indicating whether to scan for rule files recursively.
-
-        Returns:
-            a list of dictionaries representing prometheus alert rule groups, each dictionary
-            representing an alert group (structure determined by `yaml.safe_load`).
-        """
-        alert_groups = []  # type: List[dict]
-
-        # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(
-            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
-        ):
-            alert_groups_from_file = self._from_file(dir_path, file_path)
-            if alert_groups_from_file:
-                logger.debug("Reading alert rule from %s", file_path)
-                alert_groups.extend(alert_groups_from_file)
-
-        return alert_groups
-
-    def add_path(self, path: str, *, recursive: bool = False) -> None:
-        """Add rules from a dir path.
-
-        All rules from files are aggregated into a data structure representing a single rule file.
-        All group names are augmented with juju topology.
-
-        Args:
-            path: either a rules file or a dir of rules files.
-            recursive: whether to read files recursively or not (no impact if `path` is a file).
-
-        Returns:
-            True if path was added else False.
-        """
-        path = Path(path)  # type: Path
-        if path.is_dir():
-            self.alert_groups.extend(self._from_dir(path, recursive))
-        elif path.is_file():
-            self.alert_groups.extend(self._from_file(path.parent, path))
-        else:
-            logger.debug("Alert rules path does not exist: %s", path)
-
-    def as_dict(self) -> dict:
-        """Return standard alert rules file in dict representation.
-
-        Returns:
-            a dictionary containing a single list of alert rule groups.
-            The list of alert rule groups is provided as value of the
-            "groups" dictionary key.
-        """
-        return {"groups": self.alert_groups} if self.alert_groups else {}
-
-
 class TargetsChangedEvent(EventBase):
     """Event emitted when Prometheus scrape targets change."""
 
@@ -1326,7 +1122,7 @@ class MetricsEndpointConsumer(Object):
                         # Inject topology and put it back in the list
                         rule["expr"] = self._tool.inject_label_matchers(
                             re.sub(r"%%juju_topology%%,?", "", rule["expr"]),
-                            topology.label_matcher_dict,
+                            topology.alert_expression_dict,
                         )
                     except KeyError:
                         # Some required JujuTopology key is missing. Just move on.
@@ -1737,7 +1533,7 @@ class MetricsEndpointProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules(topology=self.topology)
+        alert_rules = AlertRules(query_type="promql", topology=self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -1884,7 +1680,7 @@ class PrometheusRulesProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules()
+        alert_rules = AlertRules(query_type="promql")
         alert_rules.add_path(self.dir_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -346,8 +346,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import yaml
-from cosl import JujuTopology
-from cosl.rules import AlertRules
+from charms.observability_libs.v0.juju_topology import JujuTopology
 from ops.charm import CharmBase, RelationRole
 from ops.framework import (
     BoundEvent,
@@ -369,9 +368,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 40
-
-PYDEPS = ["cosl"]
+LIBPATCH = 39
 
 logger = logging.getLogger(__name__)
 
@@ -837,6 +834,206 @@ def _is_single_alert_rule_format(rules_dict: dict) -> bool:
     """
     # one alert rule per file
     return set(rules_dict) >= {"alert", "expr"}
+
+
+class AlertRules:
+    """Utility class for amalgamating prometheus alert rule files and injecting juju topology.
+
+    An `AlertRules` object supports aggregating alert rules from files and directories in both
+    official and single rule file formats using the `add_path()` method. All the alert rules
+    read are annotated with Juju topology labels and amalgamated into a single data structure
+    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
+    easily dumped into JSON format and exchanged over relation data. The dictionary can also
+    be dumped into YAML format and written directly into an alert rules file that is read by
+    Prometheus. Note that multiple `AlertRules` objects must not be written into the same file,
+    since Prometheus allows only a single list of alert rule groups per alert rules file.
+
+    The official Prometheus format is a YAML file conforming to the Prometheus documentation
+    (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+    The custom single rule format is a subsection of the official YAML, having a single alert
+    rule, effectively "one alert per file".
+    """
+
+    # This class uses the following terminology for the various parts of a rule file:
+    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
+    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
+    #   of dictionaries that have the "name" and "rules" keys.
+    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
+    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
+    #   the "alert" and "expr" keys.
+    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
+
+    def __init__(self, topology: Optional[JujuTopology] = None):
+        """Build and alert rule object.
+
+        Args:
+            topology: an optional `JujuTopology` instance that is used to annotate all alert rules.
+        """
+        self.topology = topology
+        self.tool = CosTool(None)
+        self.alert_groups = []  # type: List[dict]
+
+    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
+        """Read a rules file from path, injecting juju topology.
+
+        Args:
+            root_path: full path to the root rules folder (used only for generating group name)
+            file_path: full path to a *.rule file.
+
+        Returns:
+            A list of dictionaries representing the rules file, if file is valid (the structure is
+            formed by `yaml.safe_load` of the file); an empty list otherwise.
+        """
+        with file_path.open() as rf:
+            # Load a list of rules from file then add labels and filters
+            try:
+                rule_file = yaml.safe_load(rf)
+
+            except Exception as e:
+                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
+                return []
+
+            if not rule_file:
+                logger.warning("Empty rules file: %s", file_path.name)
+                return []
+            if not isinstance(rule_file, dict):
+                logger.error("Invalid rules file (must be a dict): %s", file_path.name)
+                return []
+            if _is_official_alert_rule_format(rule_file):
+                alert_groups = rule_file["groups"]
+            elif _is_single_alert_rule_format(rule_file):
+                # convert to list of alert groups
+                # group name is made up from the file name
+                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
+            else:
+                # invalid/unsupported
+                logger.error("Invalid rules file: %s", file_path.name)
+                return []
+
+            # update rules with additional metadata
+            for alert_group in alert_groups:
+                # update group name with topology and sub-path
+                alert_group["name"] = self._group_name(
+                    str(root_path),
+                    str(file_path),
+                    alert_group["name"],
+                )
+
+                # add "juju_" topology labels
+                for alert_rule in alert_group["rules"]:
+                    if "labels" not in alert_rule:
+                        alert_rule["labels"] = {}
+
+                    if self.topology:
+                        alert_rule["labels"].update(self.topology.label_matcher_dict)
+                        # insert juju topology filters into a prometheus alert rule
+                        alert_rule["expr"] = self.tool.inject_label_matchers(
+                            re.sub(r"%%juju_topology%%,?", "", alert_rule["expr"]),
+                            self.topology.label_matcher_dict,
+                        )
+
+            return alert_groups
+
+    def _group_name(self, root_path: str, file_path: str, group_name: str) -> str:
+        """Generate group name from path and topology.
+
+        The group name is made up of the relative path between the root dir_path, the file path,
+        and topology identifier.
+
+        Args:
+            root_path: path to the root rules dir.
+            file_path: path to rule file.
+            group_name: original group name to keep as part of the new augmented group name
+
+        Returns:
+            New group name, augmented by juju topology and relative path.
+        """
+        rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
+        rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
+
+        # Generate group name:
+        #  - name, from juju topology
+        #  - suffix, from the relative path of the rule file;
+        group_name_parts = [self.topology.identifier] if self.topology else []
+        group_name_parts.extend([rel_path, group_name, "alerts"])
+        # filter to remove empty strings
+        return "_".join(filter(None, group_name_parts))
+
+    @classmethod
+    def _multi_suffix_glob(
+        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
+    ) -> list:
+        """Helper function for getting all files in a directory that have a matching suffix.
+
+        Args:
+            dir_path: path to the directory to glob from.
+            suffixes: list of suffixes to include in the glob (items should begin with a period).
+            recursive: a flag indicating whether a glob is recursive (nested) or not.
+
+        Returns:
+            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
+        """
+        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
+        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
+
+    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
+        """Read all rule files in a directory.
+
+        All rules from files for the same directory are loaded into a single
+        group. The generated name of this group includes juju topology.
+        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
+
+        Args:
+            dir_path: directory containing *.rule files (alert rules without groups).
+            recursive: flag indicating whether to scan for rule files recursively.
+
+        Returns:
+            a list of dictionaries representing prometheus alert rule groups, each dictionary
+            representing an alert group (structure determined by `yaml.safe_load`).
+        """
+        alert_groups = []  # type: List[dict]
+
+        # Gather all alerts into a list of groups
+        for file_path in self._multi_suffix_glob(
+            dir_path, [".rule", ".rules", ".yml", ".yaml"], recursive
+        ):
+            alert_groups_from_file = self._from_file(dir_path, file_path)
+            if alert_groups_from_file:
+                logger.debug("Reading alert rule from %s", file_path)
+                alert_groups.extend(alert_groups_from_file)
+
+        return alert_groups
+
+    def add_path(self, path: str, *, recursive: bool = False) -> None:
+        """Add rules from a dir path.
+
+        All rules from files are aggregated into a data structure representing a single rule file.
+        All group names are augmented with juju topology.
+
+        Args:
+            path: either a rules file or a dir of rules files.
+            recursive: whether to read files recursively or not (no impact if `path` is a file).
+
+        Returns:
+            True if path was added else False.
+        """
+        path = Path(path)  # type: Path
+        if path.is_dir():
+            self.alert_groups.extend(self._from_dir(path, recursive))
+        elif path.is_file():
+            self.alert_groups.extend(self._from_file(path.parent, path))
+        else:
+            logger.debug("Alert rules path does not exist: %s", path)
+
+    def as_dict(self) -> dict:
+        """Return standard alert rules file in dict representation.
+
+        Returns:
+            a dictionary containing a single list of alert rule groups.
+            The list of alert rule groups is provided as value of the
+            "groups" dictionary key.
+        """
+        return {"groups": self.alert_groups} if self.alert_groups else {}
 
 
 class TargetsChangedEvent(EventBase):
@@ -1540,7 +1737,7 @@ class MetricsEndpointProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules(query_type="promql", topology=self.topology)
+        alert_rules = AlertRules(topology=self.topology)
         alert_rules.add_path(self._alert_rules_path, recursive=True)
         alert_rules_as_dict = alert_rules.as_dict()
 
@@ -1687,7 +1884,7 @@ class PrometheusRulesProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        alert_rules = AlertRules(query_type="promql")
+        alert_rules = AlertRules()
         alert_rules.add_path(self.dir_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
 

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -192,7 +192,7 @@ class TraefikRouteProvider(Object):
         return list(self._charm.model.relations[self._relation_name])
 
     def _update_stored(self) -> None:
-        """Ensure that the stored host is up-to-date.
+        """Ensure that the stored data is up-to-date.
 
         This is split out into a separate method since, in the case of multi-unit deployments,
         removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
@@ -209,9 +209,9 @@ class TraefikRouteProvider(Object):
                 self._stored.scheme = ""
                 return
             external_host = relation.data[relation.app].get("external_host", "")
-            self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+            self._stored.external_host = external_host or self._stored.external_host
             scheme = relation.data[relation.app].get("scheme", "")
-            self._stored.scheme = scheme or self._stored.scheme  # type: ignore
+            self._stored.scheme = scheme or self._stored.scheme
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
@@ -317,9 +317,9 @@ class TraefikRouteRequirer(Object):
                     self._stored.scheme = ""
                     return
                 external_host = relation.data[relation.app].get("external_host", "")
-                self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+                self._stored.external_host = external_host or self._stored.external_host
                 scheme = relation.data[relation.app].get("scheme", "")
-                self._stored.scheme = scheme or self._stored.scheme  # type: ignore
+                self._stored.scheme = scheme or self._stored.scheme
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         """Update StoredState with external_host and other information from Traefik."""

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 log = logging.getLogger(__name__)
 
@@ -141,7 +141,12 @@ class TraefikRouteProvider(Object):
     _stored = StoredState()
 
     def __init__(
-        self, charm: CharmBase, relation_name: str = "traefik-route", external_host: str = ""
+        self,
+        charm: CharmBase,
+        relation_name: str = "traefik-route",
+        external_host: str = "",
+        *,
+        scheme: str = "http",
     ):
         """Constructor for TraefikRouteProvider.
 
@@ -150,17 +155,17 @@ class TraefikRouteProvider(Object):
             relation_name: The name of the relation relation_name to bind to
                 (defaults to "traefik-route").
             external_host: The external host.
+            scheme: The scheme.
         """
         super().__init__(charm, relation_name)
-        self._stored.set_default(external_host=None)
+        self._stored.set_default(external_host=None, scheme=None)
 
         self._charm = charm
         self._relation_name = relation_name
 
-        if self._stored.external_host != external_host:
-            # If external_host changed, update
-            self._stored.external_host = external_host
-            self._update_requirers_with_external_host()
+        if self._stored.external_host != external_host or self._stored.scheme != scheme:
+            # If traefik endpoint details changed, update
+            self.update_traefik_address(external_host=external_host, scheme=scheme)
 
         self.framework.observe(
             self._charm.on[relation_name].relation_changed, self._on_relation_changed
@@ -172,15 +177,21 @@ class TraefikRouteProvider(Object):
     @property
     def external_host(self) -> str:
         """Return the external host set by Traefik, if any."""
-        self._update_stored_external_host()
+        self._update_stored()
         return self._stored.external_host or ""  # type: ignore
+
+    @property
+    def scheme(self) -> str:
+        """Return the scheme set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.scheme or ""  # type: ignore
 
     @property
     def relations(self):
         """The list of Relation instances associated with this endpoint."""
         return list(self._charm.model.relations[self._relation_name])
 
-    def _update_stored_external_host(self) -> None:
+    def _update_stored(self) -> None:
         """Ensure that the stored host is up-to-date.
 
         This is split out into a separate method since, in the case of multi-unit deployments,
@@ -189,30 +200,43 @@ class TraefikRouteProvider(Object):
         allows for re-use both when the property is called and if the relation changes, so a
         leader change where the new leader checks the property will do the right thing.
         """
-        if self._charm.unit.is_leader():
-            for relation in self._charm.model.relations[self._relation_name]:
-                if not relation.app:
-                    self._stored.external_host = ""
-                    return
-                external_host = relation.data[relation.app].get("external_host", "")
-                self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+        if not self._charm.unit.is_leader():
+            return
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            if not relation.app:
+                self._stored.external_host = ""
+                self._stored.scheme = ""
+                return
+            external_host = relation.data[relation.app].get("external_host", "")
+            self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+            scheme = relation.data[relation.app].get("scheme", "")
+            self._stored.scheme = scheme or self._stored.scheme  # type: ignore
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
             # todo check data is valid here?
-            self._update_requirers_with_external_host()
+            self.update_traefik_address()
             self.on.ready.emit(event.relation)
 
     def _on_relation_broken(self, event: RelationEvent):
         self.on.data_removed.emit(event.relation)
 
-    def _update_requirers_with_external_host(self):
+    def update_traefik_address(
+        self, *, external_host: Optional[str] = None, scheme: Optional[str] = None
+    ):
         """Ensure that requirers know the external host for Traefik."""
         if not self._charm.unit.is_leader():
             return
 
         for relation in self._charm.model.relations[self._relation_name]:
-            relation.data[self._charm.app]["external_host"] = self.external_host
+            relation.data[self._charm.app]["external_host"] = external_host or self.external_host
+            relation.data[self._charm.app]["scheme"] = scheme or self.scheme
+
+        # We first attempt to write relation data (which may raise) and only then update stored
+        # state.
+        self._stored.external_host = external_host
+        self._stored.scheme = scheme
 
     @staticmethod
     def is_ready(relation: Relation) -> bool:
@@ -250,7 +274,7 @@ class TraefikRouteRequirer(Object):
 
     def __init__(self, charm: CharmBase, relation: Relation, relation_name: str = "traefik-route"):
         super(TraefikRouteRequirer, self).__init__(charm, relation_name)
-        self._stored.set_default(external_host=None)
+        self._stored.set_default(external_host=None, scheme=None)
 
         self._charm = charm
         self._relation = relation
@@ -265,10 +289,16 @@ class TraefikRouteRequirer(Object):
     @property
     def external_host(self) -> str:
         """Return the external host set by Traefik, if any."""
-        self._update_stored_external_host()
+        self._update_stored()
         return self._stored.external_host or ""  # type: ignore
 
-    def _update_stored_external_host(self) -> None:
+    @property
+    def scheme(self) -> str:
+        """Return the scheme set by Traefik, if any."""
+        self._update_stored()
+        return self._stored.scheme or ""  # type: ignore
+
+    def _update_stored(self) -> None:
         """Ensure that the stored host is up-to-date.
 
         This is split out into a separate method since, in the case of multi-unit deployments,
@@ -277,18 +307,23 @@ class TraefikRouteRequirer(Object):
         allows for re-use both when the property is called and if the relation changes, so a
         leader change where the new leader checks the property will do the right thing.
         """
-        if self._charm.unit.is_leader():
-            if self._relation:
-                for relation in self._charm.model.relations[self._relation.name]:
-                    if not relation.app:
-                        self._stored.external_host = ""
-                        return
-                    external_host = relation.data[relation.app].get("external_host", "")
-                    self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+        if not self._charm.unit.is_leader():
+            return
+
+        if self._relation:
+            for relation in self._charm.model.relations[self._relation.name]:
+                if not relation.app:
+                    self._stored.external_host = ""
+                    self._stored.scheme = ""
+                    return
+                external_host = relation.data[relation.app].get("external_host", "")
+                self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+                scheme = relation.data[relation.app].get("scheme", "")
+                self._stored.scheme = scheme or self._stored.scheme  # type: ignore
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         """Update StoredState with external_host and other information from Traefik."""
-        self._update_stored_external_host()
+        self._update_stored()
         if self._charm.unit.is_leader():
             self.on.ready.emit(event.relation)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -142,9 +142,7 @@ class GrafanaCharm(CharmBase):
         self.framework.observe(self.cert_handler.on.cert_changed, self._configure_ingress)
 
         # Assuming FQDN is always part of the SANs DNS.
-        self.grafana_service = Grafana(
-            f"{self._scheme}://{socket.getfqdn()}:{PORT}"
-        )
+        self.grafana_service = Grafana(f"{self._scheme}://{socket.getfqdn()}:{PORT}")
 
         self.metrics_endpoint = MetricsEndpointProvider(
             charm=self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -736,27 +736,6 @@ class GrafanaCharm(CharmBase):
         data.close()
         return ret
 
-    def _generate_network_config(self) -> str:
-        """Generate a network configuration.
-
-        Returns:
-            A string containing the required networking information to be stubbed into the
-            config file.
-        """
-        config_ini = configparser.ConfigParser()
-
-        config_ini["server"] = {  # pyright: ignore
-            "cert_key": "/etc/grafana/grafana.key",
-            "cert_file": "/etc/grafana/grafana.crt",
-        }
-
-        data = StringIO()
-        config_ini.write(data)
-        data.seek(0)
-        ret = data.read()
-        data.close()
-        return ret
-
     #####################################
 
     # PEBBLE OPERATIONS

--- a/src/charm.py
+++ b/src/charm.py
@@ -887,11 +887,10 @@ class GrafanaCharm(CharmBase):
             {
                 "GF_SERVER_SERVE_FROM_SUB_PATH": "False",
                 "GF_SERVER_ROOT_URL": self.external_url,
-                # FIXME From https://grafana.com/tutorials/run-grafana-behind-a-proxy/#1:
-                #  "The protocol setting should be set to http, because the TLS handshake is being
-                #  handled by NGINX."
-                #  For us, this means that when traefik provides TLS termination then traefik is
-                #  https, but grafana is http, in which case we may need to set GF_SERVER_PROTOCOL.
+                # When traefik provides TLS termination then traefik is https, but grafana is http.
+                # We need to set GF_SERVER_PROTOCOL.
+                # https://grafana.com/tutorials/run-grafana-behind-a-proxy/#1
+                "GF_SERVER_PROTOCOL": self._scheme,
             }
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1184,10 +1184,10 @@ class GrafanaCharm(CharmBase):
         """Return the external hostname configured, if any."""
         if self.ingress.external_host:
             path_prefix = f"{self.model.name}-{self.model.app.name}"
-            # FIXME self._scheme is incorrect: it needs to be the ingress URL's scheme:
-            #  If traefik is providing TLS termination then the ingress scheme is https, but
-            #  grafana's scheme is still http (cf. alertmanager's CatalogueItem).
-            return f"{self._scheme}://{self.ingress.external_host}/{path_prefix}"
+            # The scheme we use here needs to be the ingress URL's scheme:
+            # If traefik is providing TLS termination then the ingress scheme is https, but
+            # grafana's scheme is still http.
+            return f"{self.ingress.scheme}://{self.ingress.external_host}/{path_prefix}"
         return self.internal_url
 
     @property

--- a/tests/manual/bundle_1_ingress.yaml
+++ b/tests/manual/bundle_1_ingress.yaml
@@ -1,0 +1,65 @@
+# Key relations: catalogue - grafana - traefik
+# We need prom to make sure grafana can post requests and display a graph.
+
+# To test:
+# - Catalogue has the correct link (http://<traefik ip>/<model name>-graf).
+# - Able to log in from http://<traefik ip>/<model name>-graf.
+#   - All dashboards are listed:
+#     - Prometheus Operator Overview
+#     - Grafana Operator Overview
+#     - Traefik
+#   - Recent data is displayed in the graphs.
+# - Able to log in from <unit ip>:3000 and <app ip>:3000.
+#   - Recent data is displayed in the graphs.
+
+# WORKS:
+#            GF_SERVER_PROTOCOL: http
+#            GF_SERVER_ROOT_URL: http://10.43.8.149/b1-graf
+#            GF_SERVER_SERVE_FROM_SUB_PATH: "True"
+
+bundle: kubernetes
+applications:
+  cat:
+    charm: catalogue-k8s
+    channel: edge
+    series: focal
+    scale: 1
+  graf:
+    charm: ../../grafana-k8s_ubuntu-20.04-amd64.charm
+    series: focal
+    resources:
+      grafana-image: docker.io/ubuntu/grafana:9.2-22.04_beta
+      litestream-image: docker.io/litestream/litestream:0.4.0-beta.2
+    scale: 1
+    trust: true
+  prom:
+    charm: prometheus-k8s
+    channel: edge
+#    charm: ../../prometheus-k8s_ubuntu-20.04-amd64.charm
+#    resources:
+#      prometheus-image: ghcr.io/canonical/prometheus:latest
+    series: focal
+    scale: 1
+    trust: true
+  trfk:
+    charm: traefik-k8s
+    channel: edge
+#    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
+#    resources:
+#      traefik-image: ghcr.io/canonical/traefik:2.10.4
+    series: focal
+    scale: 1
+    trust: true
+relations:
+- - graf:catalogue
+  - cat:catalogue
+- - graf:ingress
+  - trfk:traefik-route
+- - prom:metrics-endpoint
+  - graf:metrics-endpoint
+- - prom:grafana-dashboard
+  - graf:grafana-dashboard
+- - prom:grafana-source
+  - graf:grafana-source
+- - trfk:grafana-dashboard
+  - graf:grafana-dashboard

--- a/tests/manual/bundle_1_ingress.yaml
+++ b/tests/manual/bundle_1_ingress.yaml
@@ -12,11 +12,6 @@
 # - Able to log in from <unit ip>:3000 and <app ip>:3000.
 #   - Recent data is displayed in the graphs.
 
-# WORKS:
-#            GF_SERVER_PROTOCOL: http
-#            GF_SERVER_ROOT_URL: http://10.43.8.149/b1-graf
-#            GF_SERVER_SERVE_FROM_SUB_PATH: "True"
-
 bundle: kubernetes
 applications:
   cat:

--- a/tests/manual/bundle_2_tls_termination.yaml
+++ b/tests/manual/bundle_2_tls_termination.yaml
@@ -1,0 +1,72 @@
+# Key relations: catalogue - grafana - traefik - ca
+# We need prom to make sure grafana can post requests and display a graph.
+
+# To test:
+# - Catalogue has the correct link (https://<traefik ip>/<model name>-graf).
+# - Able to log in from https://<traefik ip>/<model name>-graf.
+#   - All dashboards are listed:
+#     - Prometheus Operator Overview
+#     - Grafana Operator Overview
+#     - Traefik
+#   - Recent data is displayed in the graphs.
+# - When accessing the ingress url with http, it is upgraded to https.
+# - Able to log in from <unit ip>:3000 and <app ip>:3000.
+#   - Recent data is displayed in the graphs.
+
+# WORKS:
+#            GF_SERVER_PROTOCOL: http
+#            GF_SERVER_ROOT_URL: https://10.43.8.149/b1-graf
+#            GF_SERVER_SERVE_FROM_SUB_PATH: "True"
+
+bundle: kubernetes
+applications:
+  ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+  cat:
+    charm: catalogue-k8s
+    channel: edge
+    series: focal
+    scale: 1
+  graf:
+    charm: ../../grafana-k8s_ubuntu-20.04-amd64.charm
+    series: focal
+    resources:
+      grafana-image: docker.io/ubuntu/grafana:9.2-22.04_beta
+      litestream-image: docker.io/litestream/litestream:0.4.0-beta.2
+    scale: 1
+    trust: true
+  prom:
+    charm: prometheus-k8s
+    channel: edge
+#    charm: ../../prometheus-k8s_ubuntu-20.04-amd64.charm
+#    resources:
+#      prometheus-image: ghcr.io/canonical/prometheus:latest
+    series: focal
+    scale: 1
+    trust: true
+  trfk:
+#    charm: traefik-k8s
+#    channel: edge
+    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
+    resources:
+      traefik-image: ghcr.io/canonical/traefik:2.10.4
+    series: focal
+    scale: 1
+    trust: true
+relations:
+- - ca:certificates
+  - trfk:certificates
+- - graf:catalogue
+  - cat:catalogue
+- - graf:ingress
+  - trfk:traefik-route
+- - prom:metrics-endpoint
+  - graf:metrics-endpoint
+- - prom:grafana-dashboard
+  - graf:grafana-dashboard
+- - prom:grafana-source
+  - graf:grafana-source
+- - trfk:grafana-dashboard
+  - graf:grafana-dashboard

--- a/tests/manual/bundle_2_tls_termination.yaml
+++ b/tests/manual/bundle_2_tls_termination.yaml
@@ -13,11 +13,6 @@
 # - Able to log in from <unit ip>:3000 and <app ip>:3000.
 #   - Recent data is displayed in the graphs.
 
-# WORKS:
-#            GF_SERVER_PROTOCOL: http
-#            GF_SERVER_ROOT_URL: https://10.43.8.149/b1-graf
-#            GF_SERVER_SERVE_FROM_SUB_PATH: "True"
-
 bundle: kubernetes
 applications:
   ca:
@@ -47,11 +42,11 @@ applications:
     scale: 1
     trust: true
   trfk:
-#    charm: traefik-k8s
-#    channel: edge
-    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
-    resources:
-      traefik-image: ghcr.io/canonical/traefik:2.10.4
+    charm: traefik-k8s
+    channel: edge
+#    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
+#    resources:
+#      traefik-image: ghcr.io/canonical/traefik:2.10.4
     series: focal
     scale: 1
     trust: true

--- a/tests/manual/bundle_3_end_to_end_tls.yaml
+++ b/tests/manual/bundle_3_end_to_end_tls.yaml
@@ -42,11 +42,11 @@ applications:
     scale: 1
     trust: true
   trfk:
-#    charm: traefik-k8s
-#    channel: edge
-    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
-    resources:
-      traefik-image: ghcr.io/canonical/traefik:2.10.4
+    charm: traefik-k8s
+    channel: edge
+#    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
+#    resources:
+#      traefik-image: ghcr.io/canonical/traefik:2.10.4
     series: focal
     scale: 1
     trust: true

--- a/tests/manual/bundle_3_end_to_end_tls.yaml
+++ b/tests/manual/bundle_3_end_to_end_tls.yaml
@@ -1,0 +1,71 @@
+# Key relations: catalogue - (grafana - ca) - traefik - ca
+# We need prom to make sure grafana can post requests and display a graph.
+
+# To test:
+# - Catalogue has the correct link (https://<traefik ip>/<model name>-graf).
+# - Able to log in.
+#   - All dashboards are listed:
+#     - Prometheus Operator Overview
+#     - Grafana Operator Overview
+#     - Traefik
+# - Recent data is displayed in the graphs.
+# - Attempting "http" is upgraded to https.
+# - Able to log in from <unit ip>:3000 and <app ip>:3000.
+#   - Recent data is displayed in the graphs.
+
+bundle: kubernetes
+applications:
+  ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+  cat:
+    charm: catalogue-k8s
+    channel: edge
+    series: focal
+    scale: 1
+  graf:
+    charm: ../../grafana-k8s_ubuntu-20.04-amd64.charm
+    series: focal
+    resources:
+      grafana-image: docker.io/ubuntu/grafana:9.2-22.04_beta
+      litestream-image: docker.io/litestream/litestream:0.4.0-beta.2
+    scale: 1
+    trust: true
+  prom:
+    charm: prometheus-k8s
+    channel: edge
+#    charm: ../../prometheus-k8s_ubuntu-20.04-amd64.charm
+#    resources:
+#      prometheus-image: ghcr.io/canonical/prometheus:latest
+    series: focal
+    scale: 1
+    trust: true
+  trfk:
+#    charm: traefik-k8s
+#    channel: edge
+    charm: ../../traefik-k8s_ubuntu-20.04-amd64.charm
+    resources:
+      traefik-image: ghcr.io/canonical/traefik:2.10.4
+    series: focal
+    scale: 1
+    trust: true
+relations:
+- - ca:certificates
+  - trfk:certificates
+- - graf:catalogue
+  - cat:catalogue
+- - graf:certificates
+  - ca:certificates
+- - graf:ingress
+  - trfk:traefik-route
+- - prom:metrics-endpoint
+  - graf:metrics-endpoint
+- - prom:grafana-dashboard
+  - graf:grafana-dashboard
+- - prom:grafana-source
+  - graf:grafana-source
+- - prom:certificates
+  - ca:certificates
+- - trfk:grafana-dashboard
+  - graf:grafana-dashboard

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -286,8 +286,9 @@ class TestCharm(unittest.TestCase):
     def test_bare_charm_has_no_subpath_set_in_layer(self):
         self.harness.set_leader(True)
         layer = self.harness.charm._build_layer()
-        self.assertNotIn(
-            "GF_SERVER_ROOT_URL", layer.to_dict()["services"]["grafana"]["environment"]
+        self.assertEqual(
+            layer.to_dict()["services"]["grafana"]["environment"]["GF_SERVER_ROOT_URL"],
+            "http://grafana-k8s-0.testmodel.svc.cluster.local:3000",
         )
 
     @patch.object(grafana_client.Grafana, "build_info", new={"version": "1.0.0"})
@@ -301,8 +302,8 @@ class TestCharm(unittest.TestCase):
         services = (
             self.harness.charm.containers["workload"].get_plan().services["grafana"].to_dict()
         )
-        self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", services["environment"].keys())
-        self.assertNotIn("GF_SERVER_ROOT_URL", services["environment"].keys())
+        self.assertIn("GF_SERVER_SERVE_FROM_SUB_PATH", services["environment"].keys())
+        self.assertIn("GF_SERVER_ROOT_URL", services["environment"].keys())
 
         expected_rel_data = {
             "http": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import ops
 import yaml
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
 from ops.testing import Harness
 
 import grafana_client
@@ -292,7 +291,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch.object(grafana_client.Grafana, "build_info", new={"version": "1.0.0"})
-    @patch.object(TraefikRouteRequirer, "external_host", new="1.2.3.4")
+    @patch.multiple("charm.TraefikRouteRequirer", external_host="1.2.3.4", scheme="http")
     def test_ingress_relation_sets_options_and_rel_data(self):
         self.harness.set_leader(True)
         self.harness.container_pebble_ready("grafana")

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -83,7 +83,7 @@ class TestExternalUrl(unittest.TestCase):
         # (this is set by a mock decorator)
 
         # THEN root url and subpath envs are defined
-        self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "False")
+        self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
         self.assertEqual(
             self.get_pebble_env()["GF_SERVER_ROOT_URL"],
             "http://grafana-k8s-0.testmodel.svc.cluster.local:3000",
@@ -106,7 +106,7 @@ class TestExternalUrl(unittest.TestCase):
             )
 
             # THEN root url is fqdn and the subpath env is defined
-            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "False")
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
             self.assertEqual(
                 self.get_pebble_env()["GF_SERVER_ROOT_URL"], "http://1.2.3.4/testmodel-grafana-k8s"
             )
@@ -117,7 +117,7 @@ class TestExternalUrl(unittest.TestCase):
             self.harness.update_config({"web_external_url": external_url_config})
 
             # THEN root url is not affected
-            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "False")
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
             self.assertEqual(
                 self.get_pebble_env()["GF_SERVER_ROOT_URL"], "http://1.2.3.4/testmodel-grafana-k8s"
             )
@@ -127,7 +127,7 @@ class TestExternalUrl(unittest.TestCase):
             self.harness.update_config(unset=["web_external_url"])
 
             # THEN root url is still not affected
-            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "False")
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
             self.assertEqual(
                 self.get_pebble_env()["GF_SERVER_ROOT_URL"], "http://1.2.3.4/testmodel-grafana-k8s"
             )
@@ -138,7 +138,7 @@ class TestExternalUrl(unittest.TestCase):
             self.harness.remove_relation(rel_id)
 
             # THEN root url and subpath envs are undefined (because fqdn is a bare hostname)
-            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "False")
+            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
             self.assertEqual(
                 self.get_pebble_env()["GF_SERVER_ROOT_URL"],
                 "http://grafana-k8s-0.testmodel.svc.cluster.local:3000",

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -88,7 +88,7 @@ class TestExternalUrl(unittest.TestCase):
         self.assertTrue(self.is_service_running())
 
     def test_external_url_precedence(self):
-        """Precedence is [config option] > [ingress] > [fqdn]."""
+        """Precedence is [ingress] > [fqdn]."""
         # GIVEN a charm with the fqdn as its external URL
         # (this is set by a mock decorator)
 
@@ -96,46 +96,39 @@ class TestExternalUrl(unittest.TestCase):
         with patch.object(TraefikRouteRequirer, "external_host", new="1.2.3.4"):
             rel_id = self.harness.add_relation("ingress", "traefik-app")
             self.harness.add_relation_unit(rel_id, "traefik-app/0")
+
             # AND ingress becomes ready
             self.harness.charm.ingress.on.ready.emit(
                 self.harness.charm.model.get_relation("ingress", rel_id)
             )
 
-            # THEN root url and subpath envs are defined
-            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
-            self.assertEqual(
-                self.get_pebble_env()["GF_SERVER_ROOT_URL"],
-                "http://0.0.0.0:3000/testmodel-grafana-k8s",
-            )
+            # THEN root url is fqdn and the subpath envs are NOT defined
+            self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
+            self.assertNotIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
             self.assertTrue(self.is_service_running())
 
-            # # WHEN the web_external_url config option is set
-            # external_url_config = "http://foo.bar.config:8080/path/to/grafana"
-            # self.harness.update_config({"web_external_url": external_url_config})
+            # WHEN the web_external_url config option is set
+            external_url_config = "http://foo.bar.config:8080/path/to/grafana"
+            self.harness.update_config({"web_external_url": external_url_config})
 
-            # # THEN root url is updated (config option has higher precedence than ingress)
-            # self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
-            # self.assertEqual(
-            #     self.get_pebble_env()["GF_SERVER_ROOT_URL"], "http://0.0.0.0:8080/path/to/grafana"
-            # )
-            # self.assertTrue(self.is_service_running())
+            # THEN root url is not affected (that config option is deprecated)
+            self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
+            self.assertNotIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
+            self.assertTrue(self.is_service_running())
 
-            # # WHEN the web_external_url config option is cleared
-            # self.harness.update_config(unset=["web_external_url"])
+            # WHEN the web_external_url config option is cleared
+            self.harness.update_config(unset=["web_external_url"])
 
-            # THEN root url is reverted to the one coming from ingress
-            self.assertEqual(self.get_pebble_env()["GF_SERVER_SERVE_FROM_SUB_PATH"], "True")
-            self.assertEqual(
-                self.get_pebble_env()["GF_SERVER_ROOT_URL"],
-                "http://0.0.0.0:3000/testmodel-grafana-k8s",
-            )
+            # THEN root url is still not affected
+            self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
+            self.assertNotIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
 
         # WHEN the traefik relation is removed
         with patch.object(TraefikRouteRequirer, "external_host", new=""):
             self.harness.remove_relation_unit(rel_id, "traefik-app/0")
             self.harness.remove_relation(rel_id)
 
-            # THEN root url and subpath envs are undefined again (because fqdn is a bare hostname)
+            # THEN root url and subpath envs are undefined (because fqdn is a bare hostname)
             self.assertNotIn("GF_SERVER_SERVE_FROM_SUB_PATH", self.get_pebble_env())
             self.assertNotIn("GF_SERVER_ROOT_URL", self.get_pebble_env())
             self.assertTrue(self.is_service_running())

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -96,7 +96,7 @@ class TestExternalUrl(unittest.TestCase):
         # (this is set by a mock decorator)
 
         # WHEN a relation with traefik is formed
-        with patch.object(TraefikRouteRequirer, "external_host", new="1.2.3.4"):
+        with patch.multiple("charm.TraefikRouteRequirer", external_host="1.2.3.4", scheme="http"):
             rel_id = self.harness.add_relation("ingress", "traefik-app")
             self.harness.add_relation_unit(rel_id, "traefik-app/0")
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ deps =
     pytest
     coverage[toml]
     responses
+    cosl
     -r{toxinidir}/requirements.txt
 commands =
     /usr/bin/env sh -c 'stat sqlite-static > /dev/null 2>&1 || curl -L https://github.com/CompuRoot/static-sqlite3/releases/latest/download/sqlite3 -o sqlite-static && chmod +x sqlite-static'

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,6 @@ deps =
     pytest
     coverage[toml]
     responses
-    cosl
     -r{toxinidir}/requirements.txt
 commands =
     /usr/bin/env sh -c 'stat sqlite-static > /dev/null 2>&1 || curl -L https://github.com/CompuRoot/static-sqlite3/releases/latest/download/sqlite3 -o sqlite-static && chmod +x sqlite-static'


### PR DESCRIPTION
## Issue
The fix in #253 removed `stripPrefix` as a workaround, but we still want the stripPrefix functionality.

Depends on:
- https://github.com/canonical/prometheus-k8s-operator/pull/520

## Solution
Revert #253 and take an approach similar to https://github.com/canonical/prometheus-k8s-operator/pull/514.

Refs:
- https://github.com/grafana/grafana/blob/main/conf/defaults.ini
- https://grafana.com/tutorials/run-grafana-behind-a-proxy/

In tandem with:
- https://github.com/canonical/traefik-route-k8s-operator/pull/41
- https://github.com/canonical/traefik-k8s-operator/pull/234

Drive-by fixes:
- Differentiate scheme between grafana and traefik: In tls termination, traefik's scheme is https but grafana's is http.
- Use envvars instead of config ini.
- fetch-lib

## Testing Instructions
Navigate with a browser to the grafana endpoint using each of the newly created bundle files.


## Release Notes
Fix stripPrefix.
