### PR TITLE
implement certificate transfer interface

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,1 +1,0 @@
-lib/charms/*

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,1 @@
+lib/charms/*

--- a/lib/.wokeignore
+++ b/lib/.wokeignore
@@ -1,0 +1,1 @@
+charms/certificate_transfer_interface

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -1,0 +1,390 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the certificate_transfer relation.
+
+This library contains the Requires and Provides classes for handling the
+ertificate-transfer interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.certificate_transfer_interface.v0.certificate_transfer
+```
+
+### Provider charm
+The provider charm is the charm providing public certificates to another charm that requires them.
+
+Example:
+```python
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import CertificateTransferProvides  # noqa: E501 W505
+
+
+class DummyCertificateTransferProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificate_transfer = CertificateTransferProvides(self, "certificates")
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent):
+        certificate = "my certificate"
+        ca = "my CA certificate"
+        chain = ["certificate 1", "certificate 2"]
+        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain, relation_id=event.relation.id)
+
+
+if __name__ == "__main__":
+    main(DummyCertificateTransferProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them.
+
+Example:
+```python
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
+    CertificateAvailableEvent,
+    CertificateRemovedEvent,
+    CertificateTransferRequires,
+)
+
+
+class DummyCertificateTransferRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificate_transfer = CertificateTransferRequires(self, "certificates")
+        self.framework.observe(
+            self.certificate_transfer.on.certificate_available, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.certificate_transfer.on.certificate_removed, self._on_certificate_removed
+        )
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent):
+        print(event.certificate)
+        print(event.ca)
+        print(event.chain)
+        print(event.relation_id)
+
+    def _on_certificate_removed(self, event: CertificateRemovedEvent):
+        print(event.relation_id)
+
+
+if __name__ == "__main__":
+    main(DummyCertificateTransferRequirerCharm)
+```
+
+You can relate both charms by running:
+
+```bash
+juju relate <certificate_transfer provider charm> <certificate_transfer requirer charm>
+```
+
+"""
+
+
+import json
+import logging
+from typing import List
+
+from jsonschema import exceptions, validate  # type: ignore[import-untyped]
+from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "3785165b24a743f2b0c60de52db25c8b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 5
+
+PYDEPS = ["jsonschema"]
+
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/certificate_transfer/schemas/provider.json",  # noqa: E501
+    "type": "object",
+    "title": "`certificate_transfer` provider schema",
+    "description": "The `certificate_transfer` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
+    "default": {},
+    "examples": [
+        {
+            "certificate": "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "ca": "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "chain": [
+                "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",  # noqa: E501
+                "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            ],
+        }
+    ],
+    "properties": {
+        "certificate": {
+            "$id": "#/properties/certificate",
+            "type": "string",
+            "title": "Public TLS certificate",
+            "description": "Public TLS certificate",
+        },
+        "ca": {
+            "$id": "#/properties/ca",
+            "type": "string",
+            "title": "CA public TLS certificate",
+            "description": "CA Public TLS certificate",
+        },
+        "chain": {
+            "$id": "#/properties/chain",
+            "type": "array",
+            "items": {"type": "string", "$id": "#/properties/chain/items"},
+            "title": "CA public TLS certificate chain",
+            "description": "CA public TLS certificate chain",
+        },
+    },
+    "anyOf": [{"required": ["certificate"]}, {"required": ["ca"]}, {"required": ["chain"]}],
+    "additionalProperties": True,
+}
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        ca: str,
+        chain: List[str],
+        relation_id: int,
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.ca = ca
+        self.chain = chain
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "certificate": self.certificate,
+            "ca": self.ca,
+            "chain": self.chain,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificateRemovedEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is removed."""
+
+    def __init__(self, handle: Handle, relation_id: int):
+        super().__init__(handle)
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {"relation_id": self.relation_id}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.relation_id = snapshot["relation_id"]
+
+
+def _load_relation_data(raw_relation_data: dict) -> dict:
+    """Load relation data from the relation data bag.
+
+    Args:
+        raw_relation_data: Relation data from the databag
+
+    Returns:
+        dict: Relation data in dict format.
+    """
+    loaded_relation_data = {}
+    for key in raw_relation_data:
+        try:
+            loaded_relation_data[key] = json.loads(raw_relation_data[key])
+        except (json.decoder.JSONDecodeError, TypeError):
+            loaded_relation_data[key] = raw_relation_data[key]
+    return loaded_relation_data
+
+
+class CertificateTransferRequirerCharmEvents(CharmEvents):
+    """List of events that the Certificate Transfer requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+    certificate_removed = EventSource(CertificateRemovedEvent)
+
+
+class CertificateTransferProvides(Object):
+    """Certificate Transfer provider class."""
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def set_certificate(
+        self,
+        certificate: str,
+        ca: str,
+        chain: List[str],
+        relation_id: int,
+    ) -> None:
+        """Add certificates to relation data.
+
+        Args:
+            certificate (str): Certificate
+            ca (str): CA Certificate
+            chain (list): CA Chain
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        if not relation:
+            raise RuntimeError(
+                f"No relation found with relation name {self.relationship_name} and "
+                f"relation ID {relation_id}"
+            )
+        relation.data[self.model.unit]["certificate"] = certificate
+        relation.data[self.model.unit]["ca"] = ca
+        relation.data[self.model.unit]["chain"] = json.dumps(chain)
+
+    def remove_certificate(self, relation_id: int) -> None:
+        """Remove a given certificate from relation data.
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        if not relation:
+            logger.warning(
+                f"Can't remove certificate - Non-existent relation '{self.relationship_name}'"
+            )
+            return
+        unit_relation_data = relation.data[self.model.unit]
+        certificate_removed = False
+        if "certificate" in unit_relation_data:
+            relation.data[self.model.unit].pop("certificate")
+            certificate_removed = True
+        if "ca" in unit_relation_data:
+            relation.data[self.model.unit].pop("ca")
+            certificate_removed = True
+        if "chain" in unit_relation_data:
+            relation.data[self.model.unit].pop("chain")
+            certificate_removed = True
+
+        if certificate_removed:
+            logger.warning("Certificate removed from relation data")
+        else:
+            logger.warning("Can't remove certificate - No certificate in relation data")
+
+
+class CertificateTransferRequires(Object):
+    """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
+
+    on = CertificateTransferRequirerCharmEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+    ):
+        """Generates/use private key and observes relation changed event.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+        """
+        super().__init__(charm, relationship_name)
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_broken, self._on_relation_broken
+        )
+
+    @staticmethod
+    def _relation_data_is_valid(relation_data: dict) -> bool:
+        """Return whether relation data is valid based on json schema.
+
+        Args:
+            relation_data: Relation data in dict format.
+
+        Returns:
+            bool: Whether relation data is valid.
+        """
+        try:
+            validate(instance=relation_data, schema=PROVIDER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Emit certificate available event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not event.unit:
+            logger.info(f"No remote unit in relation: {self.relationship_name}")
+            return
+        remote_unit_relation_data = _load_relation_data(event.relation.data[event.unit])
+        if not self._relation_data_is_valid(remote_unit_relation_data):
+            logger.warning(
+                f"Provider relation data did not pass JSON Schema validation: "
+                f"{event.relation.data[event.unit]}"
+            )
+            return
+        self.on.certificate_available.emit(
+            certificate=remote_unit_relation_data.get("certificate"),
+            ca=remote_unit_relation_data.get("ca"),
+            chain=remote_unit_relation_data.get("chain"),
+            relation_id=event.relation.id,
+        )
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handler triggered on relation broken event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        self.on.certificate_removed.emit(relation_id=event.relation.id)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -52,6 +52,13 @@ requires:
     interface: tls-certificates
     limit: 1
     description: Certificate and key files for Grafana to use with TLS.
+  receive-ca-cert:
+    interface: certificate_transfer
+    description: |
+      Receive a CA cert for grafana to trust.
+      This relation can be used with a local CA to obtain the CA cert that was used to sign proxied
+      endpoints.
+    limit: 1
 
 provides:
   metrics-endpoint:
@@ -69,7 +76,7 @@ resources:
   grafana-image:
     type: oci-image
     description: upstream docker image for Grafana
-    upstream-source: docker.io/ubuntu/grafana:10-22.04
+    upstream-source: ghcr.io/canonical/grafana:dev
   litestream-image:
     type: oci-image
     description: upstream image for sqlite streaming

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -77,6 +77,8 @@ resources:
     type: oci-image
     description: upstream docker image for Grafana
     upstream-source: ghcr.io/canonical/grafana:dev
+    # TODO revert to dockerhub once the oci-factory CI is fixed
+    # upstream-source: docker.io/ubuntu/grafana:10-22.04
   litestream-image:
     type: oci-image
     description: upstream image for sqlite streaming

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,6 +49,11 @@ from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     adjust_resource_requirements,
 )
 from charms.observability_libs.v0.cert_handler import CertHandler
+from charms.certificate_transfer_interface.v0.certificate_transfer import (
+    CertificateAvailableEvent,
+    CertificateRemovedEvent,
+    CertificateTransferRequires,
+)
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
 from ops.charm import (
@@ -97,6 +102,11 @@ DATABASE = "database"
 PEER = "grafana"
 PORT = 3000
 
+# Template for storing trusted certificate in a file.
+TRUSTED_CA_TEMPLATE = string.Template(
+    "/usr/local/share/ca-certificates/trusted-ca-cert-$rel_id-ca.crt"
+)
+
 
 class GrafanaCharm(CharmBase):
     """Charm to run Grafana on Kubernetes.
@@ -130,6 +140,9 @@ class GrafanaCharm(CharmBase):
             peer_relation_name="replicas",
             extra_sans_dns=[socket.getfqdn()],
         )
+
+        # -- trusted_cert_transfer
+        self.trusted_cert_transfer = CertificateTransferRequires(self, "receive-ca-cert")
 
         # -- ingress via raw traefik_route
         # TraefikRouteRequirer expects an existing relation to be passed as part of the constructor,
@@ -228,6 +241,16 @@ class GrafanaCharm(CharmBase):
         # -- cert_handler observations
         self.framework.observe(
             self.cert_handler.on.cert_changed, self._on_server_cert_changed  # pyright: ignore
+        )
+
+        # -- trusted_cert_transfer observations
+        self.framework.observe(
+            self.trusted_cert_transfer.on.certificate_available,
+            self._on_trusted_certificate_available,  # pyright: ignore
+        )
+        self.framework.observe(
+            self.trusted_cert_transfer.on.certificate_removed,
+            self._on_trusted_certificate_removed,  # pyright: ignore
         )
 
         # self.catalog = CatalogueConsumer(charm=self, item=self._catalogue_item)
@@ -744,6 +767,10 @@ class GrafanaCharm(CharmBase):
         self.source_consumer.upgrade_keys()
         self.dashboard_consumer.update_dashboards()
         self._update_dashboards(event)
+
+        # In case of a restart caused by an error, we collect all trusted certs from relation receive-ca-cert
+        self._update_trusted_ca_certs()
+
         version = self.grafana_version
         if version is not None:
             self.unit.set_workload_version(version)
@@ -773,6 +800,9 @@ class GrafanaCharm(CharmBase):
             #   ERROR cannot start service: exited quickly with code 1
             if self.cert_handler.cert:
                 self._update_cert()
+
+            # If available, we collect all trusted certs from the receive-ca-cert relation
+            self._update_trusted_ca_certs()
 
             self.containers["workload"].start(self.name)
             logger.info("Restarted grafana-k8s")
@@ -1268,6 +1298,11 @@ class GrafanaCharm(CharmBase):
         self._update_cert()
         self._configure()
 
+    def _update_system_certs(self):
+        container = self.containers["workload"]
+        container.exec(["update-ca-certificates", "--fresh"]).wait()
+        subprocess.run(["update-ca-certificates", "--fresh"])
+
     def _update_cert(self):
         container = self.containers["workload"]
         ca_cert_path = Path("/usr/local/share/ca-certificates/cos-ca.crt")
@@ -1300,8 +1335,45 @@ class GrafanaCharm(CharmBase):
             # Repeat for the charm container.
             ca_cert_path.unlink(missing_ok=True)
 
-        container.exec(["update-ca-certificates", "--fresh"]).wait()
-        subprocess.run(["update-ca-certificates", "--fresh"])
+        self._update_system_certs()
+
+    def _on_trusted_certificate_available(self, event: CertificateAvailableEvent):
+        if not self.containers["workload"].can_connect():
+            logger.warning("Cannot connect to Pebble. Deferring event.")
+            event.defer()
+            return
+
+        self.restart_grafana()
+
+    def _update_trusted_ca_certs(self):
+        """This function receives the trusted certificates from the certificate_transfer integration."""
+        """Grafana needs to restart to use newly received certificates. Certificates attached to the
+        relation need to be pulled before Grafana is started.
+        This function is needed because relation events are not emitted on upgrade, and because we
+        do not have (nor do we want) persistent storage for certs.
+        """
+        if not self.model.get_relation(relation_name=self.trusted_cert_transfer.relationship_name):
+            return
+
+        container = self.containers["workload"]
+        for relation in self.model.relations.get(self.trusted_cert_transfer.relationship_name, []):
+            # For some reason, relation.units includes our unit and app. Need to exclude them.
+            for unit in set(relation.units).difference([self.app, self.unit]):
+                # Note: this nested loop handles the case of multi-unit CA, each unit providing
+                # a different ca cert, but that is not currently supported by the lib itself.
+                cert_path = TRUSTED_CA_TEMPLATE.substitute(rel_id=relation.id)
+                if cert := relation.data[unit].get("ca"):
+                    container.push(cert_path, cert, make_dirs=True)
+
+        self._update_system_certs()
+
+    def _on_trusted_certificate_removed(self, event: CertificateRemovedEvent):
+        # All certificates received from the relation are in separate files marked by the relation id.
+        container = self.containers["workload"]
+        cert_path = TRUSTED_CA_TEMPLATE.substitute(rel_id=event.relation_id)
+        container.remove_path(cert_path, recursive=True)
+
+        self.restart_grafana()
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -1352,6 +1352,10 @@ class GrafanaCharm(CharmBase):
         if not self.model.get_relation(relation_name=self.trusted_cert_transfer.relationship_name):
             return
 
+        logger.info(
+            "Pulling trusted ca certificates from %s relation.",
+            self.trusted_cert_transfer.relationship_name,
+        )
         container = self.containers["workload"]
         for relation in self.model.relations.get(self.trusted_cert_transfer.relationship_name, []):
             # For some reason, relation.units includes our unit and app. Need to exclude them.

--- a/tests/integration/test_trusted_certificates.py
+++ b/tests/integration/test_trusted_certificates.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from helpers import oci_image
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+grafana_resources = {
+    "grafana-image": oci_image("./metadata.yaml", "grafana-image"),
+    "litestream-image": oci_image("./metadata.yaml", "litestream-image"),
+}
+
+
+@pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
+async def test_deploy(ops_test, grafana_charm):
+    await ops_test.model.deploy(
+        grafana_charm,
+        resources=grafana_resources,
+        application_name="grafana",
+        trust=True,
+    )
+    await ops_test.model.deploy(
+        "self-signed-certificates",
+        application_name="ca",
+        channel="edge",
+        trust=True,
+    )
+
+    await ops_test.model.add_relation("grafana:receive-ca-cert", "ca")
+    await ops_test.model.wait_for_idle(
+        apps=["grafana", "ca"],
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=False,
+        timeout=1000,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_certs_created(ops_test: OpsTest):
+    """Make sure charm code creates necessary files for cert verification."""
+    unit_name = "grafana/0"
+
+    # Get relation ID
+    cmd = [
+        "sh",
+        "-c",
+        f'juju show-unit {unit_name} --format yaml | yq \'.{unit_name}."relation-info".[] | select (.endpoint=="receive-ca-cert") | ."relation-id"\'',
+    ]
+    retcode, stdout, stderr = await ops_test.run(*cmd)
+    relation_id = stdout.rstrip()
+
+    # Get relation cert
+    cmd = [
+        "sh",
+        "-c",
+        f'juju show-unit {unit_name} --format yaml | yq \'.{unit_name}."relation-info".[] | select (.endpoint=="receive-ca-cert") | ."related-units".ca/0.data.ca\'',
+    ]
+    retcode, stdout, stderr = await ops_test.run(*cmd)
+    relation_cert = stdout.rstrip()
+
+    # Get pushed cert
+    received_cert_path = f"/usr/local/share/ca-certificates/trusted-ca-cert-{relation_id}-ca.crt"
+    rc, stdout, stderr = await ops_test.juju(
+        "ssh", "--container", "grafana", unit_name, "cat", f"{received_cert_path}"
+    )
+    # Line ends have to be cleaned for comparison
+    received_cert = stdout.replace("\r\n", "\n").rstrip()
+
+    # Get trusted certs
+    trusted_certs_path = "/etc/ssl/certs/ca-certificates.crt"
+    rc, stdout, stderr = await ops_test.juju(
+        "ssh", "--container", "grafana", unit_name, "cat", f"{trusted_certs_path}"
+    )
+    # Line ends have to be cleaned for comparison
+    trusted_certs = stdout.replace("\r\n", "\n").rstrip()
+
+    assert relation_cert == received_cert
+    assert received_cert in trusted_certs
+
+
+@pytest.mark.abort_on_fail
+async def test_certs_available_after_refresh(ops_test: OpsTest, grafana_charm):
+    """Make sure trusted certs are available after update."""
+    await ops_test.model.applications["grafana"].refresh(path=grafana_charm)
+    await ops_test.model.wait_for_idle(
+        status="active", raise_on_error=False, timeout=600, idle_period=30
+    )
+    await ops_test.model.wait_for_idle(status="active")
+    await test_certs_created(ops_test)

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ description = Run scenario tests
 [testenv:integration]
 description = Run integration tests
 deps =
+    pytest-asyncio==0.21.1
     aiohttp
     asyncstdlib
     # Libjuju needs to track the juju version


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR is a solution for issue #277. 

## Solution
<!-- A summary of the solution addressing the above issue -->
This pr implements handling the self-signed-certificate's certificate_transfer interface.
When the certificate_transfer integration databag is updated with a new certificate the following steps are taken:
- Grafana app restarts.
- The cert from the relation is stored in a file in directory /usr/local/share/ca-certificates.
- Trusted certificates are updated.

When the cert is revoked by the relation, the file in /usr/local/share/ca-certificates is deleted, grafana is restarted,
and the trusted certificates are updated.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
An integration test is included to check for the received certificate being included among the trusted certificates.
```tox -e integration```

## Release Notes
<!-- A digestable summary of the change in this PR -->
