### PR TITLE
do not raise on missing peer relation when being destroyed

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -735,7 +735,7 @@ class GrafanaSourceConsumer(Object):
         """Retrieve information from the peer data bucket instead of `StoredState`."""
         peers = self._charm.peers  # type: ignore[attr-defined]
         if not peers:
-            logger.info("no peer relation: cannot get_peer_data")
+            logger.warning("get_peer_data: no peer relation. Is the charm being installed/removed?")
             return {}
 
         data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore[attr-defined]

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -160,7 +160,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 logger = logging.getLogger(__name__)
 
@@ -724,7 +724,7 @@ class GrafanaSourceConsumer(Object):
 
     def set_peer_data(self, key: str, data: Any) -> None:
         """Put information into the peer data bucket instead of `StoredState`."""
-        peers = self._charm.peers
+        peers = self._charm.peers  # type: ignore[attr-defined]
         if not peers:
             logger.info("no peer relation: skipping set_peer_data call")
             return
@@ -733,7 +733,7 @@ class GrafanaSourceConsumer(Object):
 
     def get_peer_data(self, key: str) -> Any:
         """Retrieve information from the peer data bucket instead of `StoredState`."""
-        peers = self._charm.peers
+        peers = self._charm.peers  # type: ignore[attr-defined]
         if not peers:
             logger.info("no peer relation: cannot get_peer_data")
             return {}

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -735,7 +735,9 @@ class GrafanaSourceConsumer(Object):
         """Retrieve information from the peer data bucket instead of `StoredState`."""
         peers = self._charm.peers  # type: ignore[attr-defined]
         if not peers:
-            logger.warning("get_peer_data: no peer relation. Is the charm being installed/removed?")
+            logger.warning(
+                "get_peer_data: no peer relation. Is the charm being installed/removed?"
+            )
             return {}
 
         data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore[attr-defined]

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -726,7 +726,8 @@ class GrafanaSourceConsumer(Object):
         """Put information into the peer data bucket instead of `StoredState`."""
         peers = self._charm.peers  # type: ignore[attr-defined]
         if not peers:
-            logger.info("no peer relation: skipping set_peer_data call")
+            # https://bugs.launchpad.net/juju/+bug/1998282
+            logger.info("set_peer_data: no peer relation. Is the charm being installed/removed?")
             return
 
         peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore[attr-defined]
@@ -735,6 +736,7 @@ class GrafanaSourceConsumer(Object):
         """Retrieve information from the peer data bucket instead of `StoredState`."""
         peers = self._charm.peers  # type: ignore[attr-defined]
         if not peers:
+            # https://bugs.launchpad.net/juju/+bug/1998282
             logger.warning(
                 "get_peer_data: no peer relation. Is the charm being installed/removed?"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ cryptography
 
 # lib/charms/tempo_k8s/v1/charm_tracing.py
 opentelemetry-exporter-otlp-proto-http
+pydantic

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -19,8 +19,8 @@ def ctx():
         patch.multiple(
             "charm.KubernetesComputeResourcesPatch",
             _namespace="test-namespace",
-            _patch=lambda *a, **kw: True,
-            is_ready=lambda *a, **kw: True,
+            _patch=tautology,
+            is_ready=tautology,
         ),
         patch.object(GrafanaCharm, "grafana_version", "0.1.0"),
         patch("ops.testing._TestingModelBackend.network_get"),

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+from scenario import Context
+
+from charm import GrafanaCharm
+
+
+def tautology(*_, **__) -> bool:
+    return True
+
+
+@pytest.fixture
+def ctx():
+    patches = (
+        patch("lightkube.core.client.GenericSyncClient"),
+        patch("socket.getfqdn", new=lambda *args: "grafana-k8s-0.testmodel.svc.cluster.local"),
+        patch("socket.gethostbyname", new=lambda *args: "1.2.3.4"),
+        patch.multiple(
+            "charm.KubernetesComputeResourcesPatch",
+            _namespace="test-namespace",
+            _patch=lambda *a, **kw: True,
+            is_ready=lambda *a, **kw: True,
+        ),
+        patch.object(GrafanaCharm, "grafana_version", "0.1.0"),
+        patch("ops.testing._TestingModelBackend.network_get"),
+        patch("ops.testing._TestingPebbleClient.exec", MagicMock()),
+    )
+    for p in patches:
+        p.__enter__()
+
+    yield Context(GrafanaCharm)
+
+    for p in patches:
+        p.__exit__(None, None, None)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -1,0 +1,21 @@
+import pytest
+from scenario import State, PeerRelation
+
+
+@pytest.mark.parametrize("leader", (True, False))
+def test_peer_data_does_not_raise_if_no_peers(ctx, leader):
+    state = State(leader=leader)
+    with ctx.manager("update-status", state) as mgr:
+        charm = mgr.charm
+        assert not charm.peers
+        charm.set_peer_data("1", 2)
+        assert charm.get_peer_data("1") == {}
+
+
+def test_peer_data_if_peers(ctx):
+    state = State(leader=True, relations=[PeerRelation("grafana")])
+    with ctx.manager("update-status", state) as mgr:
+        charm = mgr.charm
+        assert charm.peers
+        charm.set_peer_data("1", 2)
+        assert charm.get_peer_data("1") == 2

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,18 @@ allowlist_externals =
 
 [testenv:scenario]
 description = Run scenario tests
+deps =
+    pytest
+    responses
+    cosl
+    ops-scenario=6
+    -r{toxinidir}/requirements.txt
+commands =
+    /usr/bin/env sh -c 'stat sqlite-static > /dev/null 2>&1 || curl -L https://github.com/CompuRoot/static-sqlite3/releases/latest/download/sqlite3 -o sqlite-static && chmod +x sqlite-static'
+    /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64'
+    pytest -v --tb native -s {posargs} {[vars]tst_path}/scenario
+allowlist_externals =
+    /usr/bin/env
 
 
 [testenv:integration]

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ deps =
     pytest
     responses
     cosl
-    ops-scenario=6
+    ops-scenario==6
     -r{toxinidir}/requirements.txt
 commands =
     /usr/bin/env sh -c 'stat sqlite-static > /dev/null 2>&1 || curl -L https://github.com/CompuRoot/static-sqlite3/releases/latest/download/sqlite3 -o sqlite-static && chmod +x sqlite-static'


### PR DESCRIPTION
## Issue
Some codepaths try and access peer relation data without checking that a peer relation exists; when the app is being nuked, this raises resulting in #292 

Fixes #292 

Also I noticed there were a few inconsistencies in the assumed return type of get_peer_data, so I fixed those as well. 

added a scenario test to catch this case