### PR TITLE
Add assumes statement for `juju >= 3.0.3`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,8 +1,13 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 name: grafana-k8s
+
 assumes:
   - k8s-api
+
+  # Juju 3.0.3+ needed for secrets and open-port
+  - juju >= 3.0.3
+
 summary: Data visualization and observability with Grafana
 
 website: https://charmhub.io/grafana-k8s


### PR DESCRIPTION
## Issue
Users are able to deploy on juju 2.9.


## Solution
Add assumes statement for `juju >= 3.0.3`
