### PR TITLE
feat: Adding Terraform module

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,10 @@ on:
       - main
 
 jobs:
+  check-terraform-module:
+    name: Check Terraform Module
+    uses: canonical/observability/.github/workflows/terraform.yaml@main
+    secrets: inherit
   pull-request:
     name: PR
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@main

--- a/terraform/LICENSE
+++ b/terraform/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Canonical Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,100 @@
+# Grafana Operator for k8s Terraform Module
+
+This folder contains a base [Terraform][Terraform] module for the grafana-k8s charm.
+
+The module uses the [Terraform Juju provider][Terraform Juju provider] to model the charm
+deployment onto any Kubernetes environment managed by [Juju][Juju].
+
+The module can be used to deploy the Grafana to a Kubernetes cluster separately 
+as well as a part of a higher level Terraform module, depending on the deployment architecture.
+
+## Module structure
+
+- **main.tf** - Defines the Juju application to be deployed.
+- **variables.tf** - Allows customization of the deployment. Except for exposing the deployment
+  options (Juju model name, channel or application name) also allows overwriting charm's default
+  configuration.
+- **output.tf** - Responsible for integrating the module with other Terraform modules, primarily
+  by defining potential integration endpoints (charm integrations), but also by exposing
+  the application name.
+- **terraform.tf** - Defines the Terraform provider.
+
+## Deploying grafana-k8s base module separately
+
+### Pre-requisites
+
+- A Kubernetes cluster
+- Juju 3.x
+- Juju controller bootstrapped onto the K8s cluster
+- Terraform
+
+### Deploying Grafana with Terraform
+
+Clone the [grafana-k8s-operator][grafana-repo] Git repository.
+
+From inside the `terraform` folder, initialize the provider:
+
+```shell
+terraform init
+```
+
+Create Terraform plan:
+
+```shell
+terraform plan
+```
+
+While creating the plan, the default configuration can be overwritten with `-var-file`. To do that,
+Terraform `tfvars` file should be prepared prior to the plan creation.
+
+Deploy UPF:
+
+```console
+terraform apply -auto-approve 
+```
+
+### Cleaning up
+
+Destroy the deployment:
+
+```shell
+terraform destroy -auto-approve
+```
+
+## Using grafana-k8s base module in higher level modules
+
+If you want to use `grafana-k8s` base module as part of your Terraform module, import it
+like shown below:
+
+```text
+module "grafana" {
+  source = "git::https://github.com/canonical/grafana-k8s-operator//terraform"
+  
+  model_name = "juju_model_name"
+  config = Optional config map
+}
+```
+
+Create integrations, for instance:
+
+```text
+resource "juju_integration" "metrics" {
+  model = var.model_name
+  application {
+    name     = module.grafana.app_name
+    endpoint = module.grafana.metrics_endpoint
+  }
+  application {
+    name     = module.prometheus.app_name
+    endpoint = module.prometheus.metrics_endpoint
+  }
+}
+```
+
+The complete list of available integrations can be found [here][grafana-integrations].
+
+[Terraform]: https://www.terraform.io/
+[Terraform Juju provider]: https://registry.terraform.io/providers/juju/juju/latest
+[Juju]: https://juju.is
+[grafana-repo]: https://github.com/canonical/grafana-k8s-operator
+[grafana-integrations]: https://charmhub.io/grafana-k8s/integrations

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,16 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "grafana" {
+  name = var.app_name
+  model = var.model_name
+
+  charm {
+    name = "grafana-k8s"
+    channel = var.channel
+  }
+  config = var.config
+
+  units = 1
+  trust = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,66 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.grafana.name
+}
+
+# Required integration endpoints
+
+output "grafana_source_endpoint" {
+  description = "Name of the endpoint used by Grafana for accepting data source configurations sent by client applications."
+  value       = "grafana-source"
+}
+
+output "grafana_dashboard_endpoint" {
+  description = "Name of the endpoint used by Grafana for handling dashboards sent by client applications."
+  value       = "grafana-dashboard"
+}
+
+output "grafana_auth_endpoint" {
+  description = "Name of the endpoint used by Grafana for allowing client applications to configure authentication to Grafana."
+  value       = "grafana-auth"
+}
+
+output "database_endpoint" {
+  description = "Name of the endpoint used to integrate with the database."
+  value       = "database"
+}
+
+output "catalogue_endpoint" {
+  description = "Name of the endpoint used by Grafana for the Catalogue integration."
+  value       = "catalogue"
+}
+
+output "ingress_endpoint" {
+  description = "Name of the endpoint used by Grafana for the ingress configuration."
+  value       = "ingress"
+}
+
+output "certificates_endpoint" {
+  description = "Name of the endpoint used to integrate with the TLS certificates provider."
+  value       = "certificates"
+}
+
+output "receive_ca_cert_endpoint" {
+  description = "Name of the endpoint used with a local CA to obtain the CA cert that was used to sign proxied endpoints."
+  value       = "receive-ca-cert"
+}
+
+output "oauth_endpoint" {
+  description = "Name of the endpoint used to integrate Grafana with an oAuth2/OIDC Provider."
+  value       = "oauth"
+}
+
+output "tracing_endpoint" {
+  description = "Name of the endpoint used by Grafana for pushing traces to a tracing endpoint provided by Tempo."
+  value       = "tracing"
+}
+
+# Provided integration endpoints
+
+output "metrics_endpoint" {
+  description = "Exposes the Prometheus metrics endpoint providing telemetry about the Grafana instance."
+  value       = "metrics-endpoint"
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,11 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.10.1"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,26 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "model_name" {
+  description = "Name of the Juju model to deploy application to."
+  type        = string
+  default     = ""
+}
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "alertmanager"
+}
+
+variable "channel" {
+  description = "Channel to use when deploying a charm."
+  type        = string
+  default     = "stable"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/grafana-k8s/configure."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "model_name" {
 variable "app_name" {
   description = "Name of the application in the Juju model."
   type        = string
-  default     = "alertmanager"
+  default     = "grafana"
 }
 
 variable "channel" {


### PR DESCRIPTION
Context:
Telco team is trying to build Terraform modules for the [Charmed 5G](https://canonical-charmed-5g.readthedocs-hosted.com/en/latest/), using the Juju Terraform provider. Main reason for having Terraform modules is that, unlike Juju bundles, they support day 2 operations.

This PR adds a Terraform module for the Grafana charm. 
The module uses [Terraform Juju provider](https://registry.terraform.io/providers/juju/juju/latest) and allows deploying Alertmanager using Terraform.

All details regarding module's architecture are available in `terraform/README.md`.

In the next step, this base module will be used by the `cos-lite` Terraform module ([prototype here](https://github.com/Gmerold/terraform-juju-cos-lite-k8s/tree/cos-lite-module)).