### PR TITLE
install-plugin action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -3,3 +3,18 @@ get-admin-password:
     Get the dashboard url and initial admin password for the Grafana web interface. Initial
     admin password is generated at charm deployment time. If the password has been changed,
     a notice of that fact will be returned by this action instead.
+
+install-plugin:
+  description: |
+    Installs a grafana plugin.
+  params:
+    name:
+      type: string
+      description: |
+        Name of the plugin. Must be hosted at https://grafana.com/grafana/plugins`.
+        For example "grafana-snowflake-datasource" or "grafana-piechart-panel".
+    version:
+      type: string
+      description: |  
+        Full version of the plugin you want to install. 
+        Must include major, minor, and revision. For example "1.2.3" or "0.0.1"


### PR DESCRIPTION
adds a development action to download and install into grafana a plugin.

Usage:
`juju run grafana install-plugin some-plugin 1.0.0`

The script will grab the plugin from `grafana.com/api/plugins/some-plugin/versions/1.0.0/downloads`, and unzip it into `/var/lib/grafana/plugins`, then restart grafana and the plugin should be there.

Can't test it at the moment because `charmcraft pack` is bork on main.