### PR TITLE
workload tracing for grafana

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -193,6 +193,8 @@ class GrafanaCharm(CharmBase):
                 self.cert_handler.on.cert_changed,  # pyright: ignore
             ],
         )
+
+        # todo when we bump to v2, add otlp_http for charm_tracing and otlp_grpc for the workload.
         self.tracing = TracingEndpointRequirer(self)
 
         # -- standard events
@@ -752,7 +754,7 @@ class GrafanaCharm(CharmBase):
         can be set in ENV variables, but leave for expansion later so we can
         hide auth secrets
         """
-        configs = []
+        configs = [self._generate_tracing_config()]
         if self.has_db:
             configs.append(self._generate_database_config())
         else:
@@ -766,7 +768,37 @@ class GrafanaCharm(CharmBase):
                 data.seek(0)
                 configs.append(data.read())
 
-        return "\n".join(configs)
+        return "\n".join(filter(bool, configs))
+
+    def _generate_tracing_config(self) -> str:
+        """Generate tracing configuration.
+
+        Returns:
+            A string containing the required tracing information to be stubbed into the config
+            file.
+        """
+        tracing = self.tracing
+        if not tracing.is_ready():
+            return ""
+
+        config_ini = configparser.ConfigParser()
+        config_ini["tracing.opentelemetry"] = {
+            "sampler_type": "probabilistic",
+            "sampler_param": "0.01",
+        }
+        # ref: https://github.com/grafana/grafana/blob/main/conf/defaults.ini#L1505
+        config_ini["tracing.opentelemetry.otlp"] = {
+            "address": tracing.otlp_grpc_endpoint(),
+        }
+
+        # This is silly, but a ConfigParser() handles this nicer than
+        # raw string manipulation
+        data = StringIO()
+        config_ini.write(data)
+        data.seek(0)
+        ret = data.read()
+        data.close()
+        return ret
 
     def _generate_database_config(self) -> str:
         """Generate a database configuration.


### PR DESCRIPTION
![image](https://github.com/canonical/grafana-k8s-operator/assets/6230162/991ba61e-6a7a-4033-b2b0-234932dcf273)

Cool!

To test:
```
juju deploy cos-lite --channel=edge --trust
juju deploy ./this-tempo-charm.charm tempo
juju relate tempo-k8s:tracing grafana
juju relate tempo-k8s:grafana-source grafana
juju relate tempo-k8s:grafana-dashboard grafana
```

Go to the grafana dashboard / the tempo datasource

- profit
