### PR TITLE
Restart grafana after updating dashboards

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -648,6 +648,9 @@ class GrafanaCharm(CharmBase):
         except ConnectionError:
             logger.exception("Could not update dashboards. Pebble shutting down?")
 
+        # Restart grafana here to pick up the changed dashboards
+        self.restart_grafana()
+
     def set_ports(self):
         """Open necessary (and close no longer needed) workload ports."""
         planned_ports = {OpenedPort("tcp", PORT)} if self.unit.is_leader() else set()


### PR DESCRIPTION
This ensures that dashboard changes are picked up by grafana.

Fixes #303
