### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1033,15 +1033,15 @@ class GrafanaCharm(CharmBase):
                         "startup": "enabled",
                         "environment": {
                             "GF_SERVER_HTTP_PORT": str(PORT),
-                            "GF_LOG_LEVEL": self.model.config["log_level"],
+                            "GF_LOG_LEVEL": cast(str, self.model.config["log_level"]),
                             "GF_PLUGINS_ENABLE_ALPHA": "true",
                             "GF_PATHS_PROVISIONING": PROVISIONING_PATH,
-                            "GF_SECURITY_ALLOW_EMBEDDING": self.model.config["allow_embedding"],
-                            "GF_SECURITY_ADMIN_USER": self.model.config["admin_user"],
+                            "GF_SECURITY_ALLOW_EMBEDDING": cast(str, self.model.config["allow_embedding"]),
+                            "GF_SECURITY_ADMIN_USER": cast(str, self.model.config["admin_user"]),
                             "GF_SECURITY_ADMIN_PASSWORD": self._get_admin_password(),
-                            "GF_AUTH_ANONYMOUS_ENABLED": self.model.config[
+                            "GF_AUTH_ANONYMOUS_ENABLED": cast(str, self.model.config[
                                 "allow_anonymous_access"
-                            ],
+                            ]),
                             "GF_USERS_AUTO_ASSIGN_ORG": str(
                                 self.model.config["enable_auto_assign_org"]
                             ),
@@ -1203,7 +1203,7 @@ class GrafanaCharm(CharmBase):
 
         try:
             pw_changed = self.grafana_service.password_has_been_changed(
-                self.model.config["admin_user"], self._get_admin_password()
+                cast(str, self.model.config["admin_user"]), self._get_admin_password()
             )
         except GrafanaCommError as e:
             event.fail(f"Grafana is not reachable yet: {e}. Please try again in a few minutes.")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

Five `typing.cast` calls where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Covered above.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with/without the PR with ops 2.12 and with either the PR branch linked above or once that's merged ops main/2.13.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A