### PR TITLE
charm tracing fails over tls

### DIFF
--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -126,14 +126,15 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.trace import INVALID_SPAN, Tracer
-from opentelemetry.trace import get_current_span as otlp_get_current_span
 from opentelemetry.trace import (
+    INVALID_SPAN,
+    Tracer,
     get_tracer,
     get_tracer_provider,
     set_span_in_context,
     set_tracer_provider,
 )
+from opentelemetry.trace import get_current_span as otlp_get_current_span
 from ops.charm import CharmBase
 from ops.framework import Framework
 
@@ -146,7 +147,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -12,7 +12,7 @@ Charms seeking to push traces to Tempo, must do so using the `TracingEndpointReq
 object from this charm library. For the simplest use cases, using the `TracingEndpointRequirer`
 object only requires instantiating it, typically in the constructor of your charm. The
 `TracingEndpointRequirer` constructor requires the name of the relation over which a tracing endpoint
- is exposed by the Tempo charm, and a list of protocols it intends to send traces with. 
+ is exposed by the Tempo charm, and a list of protocols it intends to send traces with.
  This relation must use the `tracing` interface.
  The `TracingEndpointRequirer` object may be instantiated as follows
 
@@ -21,7 +21,7 @@ object only requires instantiating it, typically in the constructor of your char
     def __init__(self, *args):
         super().__init__(*args)
         # ...
-        self.tracing = TracingEndpointRequirer(self, 
+        self.tracing = TracingEndpointRequirer(self,
             protocols=['otlp_grpc', 'otlp_http', 'jaeger_http_thrift']
         )
         # ...
@@ -29,20 +29,20 @@ object only requires instantiating it, typically in the constructor of your char
 Note that the first argument (`self`) to `TracingEndpointRequirer` is always a reference to the
 parent charm.
 
-Alternatively to providing the list of requested protocols at init time, the charm can do it at 
-any point in time by calling the 
-`TracingEndpointRequirer.request_protocols(*protocol:str, relation:Optional[Relation])` method. 
+Alternatively to providing the list of requested protocols at init time, the charm can do it at
+any point in time by calling the
+`TracingEndpointRequirer.request_protocols(*protocol:str, relation:Optional[Relation])` method.
 Using this method also allows you to use per-relation protocols.
 
-Units of provider charms obtain the tempo endpoint to which they will push their traces by calling 
+Units of provider charms obtain the tempo endpoint to which they will push their traces by calling
 `TracingEndpointRequirer.get_endpoint(protocol: str)`, where `protocol` is, for example:
 - `otlp_grpc`
 - `otlp_http`
 - `zipkin`
 - `tempo`
 
-If the `protocol` is not in the list of protocols that the charm requested at endpoint set-up time, 
-the library will raise an error. 
+If the `protocol` is not in the list of protocols that the charm requested at endpoint set-up time,
+the library will raise an error.
 
 ## Requirer Library Usage
 
@@ -104,7 +104,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["pydantic"]
 
@@ -509,6 +509,7 @@ class TracingEndpointProvider(Object):
                 if an ingress is present.
             relation_name: an optional string name of the relation between `charm`
                 and the Tempo charmed service. The default is "tracing".
+            internal_scheme: scheme to use with internal urls.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -595,7 +596,7 @@ class TracingEndpointProvider(Object):
             try:
                 TracingProviderAppData(
                     host=self._host,
-                    external_url=f"http://{self._external_url}" if self._external_url else None,
+                    external_url=self._external_url or None,
                     receivers=[
                         Receiver(port=port, protocol=protocol) for protocol, port in receivers
                     ],
@@ -830,11 +831,8 @@ class TracingEndpointRequirer(Object):
         if app_data.external_url:
             url = f"{app_data.external_url}:{receiver.port}"
         else:
-            if app_data.internal_scheme:
-                url = f"{app_data.internal_scheme}://{app_data.host}:{receiver.port}"
-            else:
-                # if we didn't receive a scheme (old provider), we assume HTTP is used
-                url = f"http://{app_data.host}:{receiver.port}"
+            # if we didn't receive a scheme (old provider), we assume HTTP is used
+            url = f"{app_data.internal_scheme or 'http'}://{app_data.host}:{receiver.port}"
 
         if receiver.protocol.endswith("grpc"):
             # TCP protocols don't want an http/https scheme prefix

--- a/src/charm.py
+++ b/src/charm.py
@@ -1535,7 +1535,7 @@ class GrafanaCharm(CharmBase):
     @property
     def server_ca_cert_path(self) -> Optional[str]:
         """Server CA certificate path for TLS tracing."""
-        return CA_CERT_PATH if self.cert_handler.enabled else None
+        return str(CA_CERT_PATH) if self.cert_handler.enabled else None
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -125,7 +125,7 @@ OAUTH_GRANT_TYPES = ["authorization_code", "refresh_token"]
 
 @trace_charm(
     tracing_endpoint="tracing_endpoint",
-    server_cert="server_cert_path",
+    server_cert="server_ca_cert_path",
     extra_types=[
         AuthRequirer,
         CertHandler,
@@ -1533,9 +1533,9 @@ class GrafanaCharm(CharmBase):
         return None
 
     @property
-    def server_cert_path(self) -> Optional[str]:
-        """Server certificate path for TLS tracing."""
-        return GRAFANA_CRT_PATH
+    def server_ca_cert_path(self) -> Optional[str]:
+        """Server CA certificate path for TLS tracing."""
+        return CA_CERT_PATH if self.cert_handler.enabled else None
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ allowlist_externals = /usr/bin/env
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     coverage[toml]
     responses
     cosl
@@ -85,7 +85,7 @@ allowlist_externals =
 [testenv:scenario]
 description = Run scenario tests
 deps =
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     responses
     cosl
     ops-scenario==6
@@ -106,7 +106,7 @@ deps =
     asyncstdlib
     # Libjuju needs to track the juju version
     juju<=3.3.0,>=3.0
-    pytest
+    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
     pytest-operator
     pytest-playwright
     lightkube


### PR DESCRIPTION
## Issue
Fixes #330

## Solution
ca cert is pushed into charm container, so pass ca cert path to trace_charm decorator to use that for tls communication with tempo

## Context
1- Depends on https://github.com/canonical/tempo-k8s-operator/pull/98
2- Assumes grafana and tempo have tls enabled
3- Assumes CA of grafana is the same for the one used by tempo's cert
