### PR TITLE
Update Grafana dashboards on config changed

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1050,6 +1050,7 @@ class GrafanaDashboardProvider(Object):
 
         self.framework.observe(self._charm.on.leader_elected, self._update_all_dashboards_from_dir)
         self.framework.observe(self._charm.on.upgrade_charm, self._update_all_dashboards_from_dir)
+        self.framework.observe(self._charm.on.config_changed, self._update_all_dashboards_from_dir)
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,


### PR DESCRIPTION
## Issue
should close https://github.com/canonical/cos-configuration-k8s-operator/issues/73 once CI picks the automatic lib bump


## Solution
Add a `config-changed` event listener to the lib to update the dashboards.


## Testing Instructions

1. `juju deploy --trust grafana-k8s grafana`
2. `juju deploy cos-configuration-k8s --config git_repo=https://github.com/canonical/github-runner-operator --config git_branch=main`
3. `juju relate cos-configuration-k8s:grafana-dashboards grafana:grafana-dashboard`
4. `juju config cos-configuration-k8s grafana_dashboards_path=src/grafana_dashboards`
5. `juju show-unit grafana/0  --format json  | jq '."grafana/0"."relation-info"'`

