### PR TITLE
Fix tests to work with ops > 2.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jinja2 < 3
 lightkube >= 0.11
 markupsafe == 2.0.1
-ops
+ops <= 2.16
 pyyaml
 urllib3
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jinja2 < 3
 lightkube >= 0.11
 markupsafe == 2.0.1
-ops <= 2.16
+ops
 pyyaml
 urllib3
 jsonschema

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -23,8 +23,6 @@ def ctx():
             is_ready=tautology,
         ),
         patch.object(GrafanaCharm, "grafana_version", "0.1.0"),
-        patch("ops.testing._TestingModelBackend.network_get"),
-        patch("ops.testing._TestingPebbleClient.exec", MagicMock()),
     )
     for p in patches:
         p.__enter__()

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 from scenario import Context

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -117,6 +117,7 @@ k8s_resource_multipatch = patch.multiple(
 class BaseTestCharm(unittest.TestCase):
     def setUp(self, *unused):
         self.harness = Harness(GrafanaCharm)
+        self.harness.handle_exec('grafana', [], result=0)
         self.addCleanup(self.harness.cleanup)
 
         for p in [
@@ -125,8 +126,6 @@ class BaseTestCharm(unittest.TestCase):
             patch("socket.gethostbyname", new=lambda *args: "1.2.3.4"),
             k8s_resource_multipatch,
             patch.object(GrafanaCharm, "grafana_version", "0.1.0"),
-            patch("ops.testing._TestingModelBackend.network_get"),
-            patch("ops.testing._TestingPebbleClient.exec", MagicMock()),
         ]:
             p.start()
             self.addCleanup(p.stop)
@@ -379,13 +378,13 @@ class TestCharm(BaseTestCharm):
 class TestCharmReplication(unittest.TestCase):
     def setUp(self, *unused):
         self.harness = Harness(GrafanaCharm)
+        self.harness.handle_exec('grafana', [], result=0)
         self.addCleanup(self.harness.cleanup)
 
         for p in [
             patch("lightkube.core.client.GenericSyncClient"),
             k8s_resource_multipatch,
             patch.object(GrafanaCharm, "grafana_version", "0.1.0"),
-            patch("ops.testing._TestingPebbleClient.exec", MagicMock()),
         ]:
             p.start()
             self.addCleanup(p.stop)
@@ -399,7 +398,6 @@ class TestCharmReplication(unittest.TestCase):
         ).hexdigest()
 
     @patch("socket.getfqdn", lambda: "1.2.3.4")
-    @patch("ops.testing._TestingModelBackend.network_get")
     def test_primary_sets_correct_peer_data(self, mock_unit_ip):
         fake_network = {
             "bind-addresses": [
@@ -425,7 +423,6 @@ class TestCharmReplication(unittest.TestCase):
         self.assertEqual(unit_ip, replica_address)
 
     @patch("socket.getfqdn", lambda: "2.3.4.5")
-    @patch("ops.testing._TestingModelBackend.network_get")
     def test_replicas_get_correct_environment_variables(self, mock_unit_ip):
         fake_network = {
             "bind-addresses": [

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -117,7 +117,7 @@ k8s_resource_multipatch = patch.multiple(
 class BaseTestCharm(unittest.TestCase):
     def setUp(self, *unused):
         self.harness = Harness(GrafanaCharm)
-        self.harness.handle_exec('grafana', [], result=0)
+        self.harness.handle_exec("grafana", [], result=0)
         self.addCleanup(self.harness.cleanup)
 
         for p in [
@@ -378,7 +378,7 @@ class TestCharm(BaseTestCharm):
 class TestCharmReplication(unittest.TestCase):
     def setUp(self, *unused):
         self.harness = Harness(GrafanaCharm)
-        self.harness.handle_exec('grafana', [], result=0)
+        self.harness.handle_exec("grafana", [], result=0)
         self.addCleanup(self.harness.cleanup)
 
         for p in [
@@ -398,16 +398,7 @@ class TestCharmReplication(unittest.TestCase):
         ).hexdigest()
 
     @patch("socket.getfqdn", lambda: "1.2.3.4")
-    def test_primary_sets_correct_peer_data(self, mock_unit_ip):
-        fake_network = {
-            "bind-addresses": [
-                {
-                    "interface-name": "eth0",
-                    "addresses": [{"hostname": "grafana-0", "value": "1.2.3.4"}],
-                }
-            ]
-        }
-        mock_unit_ip.return_value = fake_network
+    def test_primary_sets_correct_peer_data(self):
 
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("grafana")
@@ -417,22 +408,14 @@ class TestCharmReplication(unittest.TestCase):
         rel = self.harness.model.get_relation("grafana")
         self.harness.add_relation_unit(rel.id, "grafana-k8s/1")
 
+        self.harness.add_network("1.2.3.4", endpoint="grafana")
         unit_ip = str(self.harness.charm.model.get_binding("grafana").network.bind_address)
         replica_address = self.harness.charm.get_peer_data("replica_primary")
 
         self.assertEqual(unit_ip, replica_address)
 
     @patch("socket.getfqdn", lambda: "2.3.4.5")
-    def test_replicas_get_correct_environment_variables(self, mock_unit_ip):
-        fake_network = {
-            "bind-addresses": [
-                {
-                    "interface-name": "eth0",
-                    "addresses": [{"hostname": "grafana-0", "value": "2.3.4.5"}],
-                }
-            ]
-        }
-        mock_unit_ip.return_value = fake_network
+    def test_replicas_get_correct_environment_variables(self):
 
         self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("grafana")

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -33,6 +33,7 @@ class TestExternalUrl(unittest.TestCase):
 
     def setUp(self, *unused):
         self.harness = Harness(GrafanaCharm)
+        self.harness.handle_exec('grafana', [], result=0)
         self.addCleanup(self.harness.cleanup)
 
         model_name = "testmodel"
@@ -45,8 +46,6 @@ class TestExternalUrl(unittest.TestCase):
             patch("socket.gethostbyname", new=lambda *args: "1.2.3.4"),
             k8s_resource_multipatch,
             patch.object(GrafanaCharm, "grafana_version", "0.0.0"),
-            patch("ops.testing._TestingModelBackend.network_get"),
-            patch("ops.testing._TestingPebbleClient.exec", MagicMock()),
         ]:
             p.start()
             self.addCleanup(p.stop)

--- a/tests/unit/test_external_url.py
+++ b/tests/unit/test_external_url.py
@@ -5,7 +5,7 @@
 import logging
 import unittest
 from typing import Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import ops
 from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
@@ -33,7 +33,7 @@ class TestExternalUrl(unittest.TestCase):
 
     def setUp(self, *unused):
         self.harness = Harness(GrafanaCharm)
-        self.harness.handle_exec('grafana', [], result=0)
+        self.harness.handle_exec("grafana", [], result=0)
         self.addCleanup(self.harness.cleanup)
 
         model_name = "testmodel"


### PR DESCRIPTION
An abundance of errors in unit tests occur when using `ops > 2.16`.

Failures like:
* `No module named 'ops.testing._TestingModelBackend'`
* `No module named 'ops.testing._TestingPebbleClient`

Fixable by replacing the patches with:

[harnes.handle_exec](https://github.com/canonical/operator/blob/e8aa2e4e5a08a3fdab75b451638bc01fa2cff7e9/ops/_private/harness.py#L1964) method