### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -15,7 +15,6 @@ output "endpoints" {
     oauth             = "oauth",
     receive_ca_cert   = "receive-ca-cert",
     tracing           = "tracing",
-    
     # Provides
     metrics_endpoint = "metrics-endpoint",
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,7 +2,7 @@ output "app_name" {
   value = juju_application.grafana.name
 }
 
-output "requires" {
+output "endpoints" {
   value = {
     catalogue         = "catalogue",
     certificates      = "certificates",
@@ -11,14 +11,9 @@ output "requires" {
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",
     ingress           = "ingress",
+    metrics_endpoint  = "metrics-endpoint",
     oauth             = "oauth",
     receive_ca_cert   = "receive-ca-cert",
     tracing           = "tracing",
-  }
-}
-
-output "provides" {
-  value = {
-    metrics_endpoint = "metrics-endpoint",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,6 +4,7 @@ output "app_name" {
 
 output "endpoints" {
   value = {
+    # Requires
     catalogue         = "catalogue",
     certificates      = "certificates",
     database          = "database",
@@ -11,9 +12,11 @@ output "endpoints" {
     grafana_dashboard = "grafana-dashboard",
     grafana_source    = "grafana-source",
     ingress           = "ingress",
-    metrics_endpoint  = "metrics-endpoint",
     oauth             = "oauth",
     receive_ca_cert   = "receive-ca-cert",
     tracing           = "tracing",
+    
+    # Provides
+    metrics_endpoint = "metrics-endpoint",
   }
 }


### PR DESCRIPTION
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Coordinating PR
- https://github.com/canonical/observability/pull/226