### PR TITLE
grafana source uid added to grafana-source interface

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -432,7 +432,8 @@ class GrafanaSourceProvider(Object):
     def get_source_uids(self) -> Dict[str, Dict[str, str]]:
         """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
 
-        Returns a mapping from remote application names to unit names to datasource uids."""
+        Returns a mapping from remote application names to unit names to datasource uids.
+        """
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -162,7 +162,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 22
 
 logger = logging.getLogger(__name__)
 
@@ -429,6 +429,15 @@ class GrafanaSourceProvider(Object):
                 continue
             self._set_sources(rel)
 
+    def get_source_uids(self) -> Dict[Relation, str]:
+        """Get the datasource UID(s) assigned by the remote end(s) to this datasource."""
+        uids = {}
+        for rel in self._charm.model.relations.get(self._relation_name, []):
+            if not rel:
+                continue
+            uids[rel] = rel.data[rel.app]["datasource_uid"]
+        return uids
+
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:
         """Get a `Relation` object from the event to pass on."""
         self._set_sources(event.relation)
@@ -551,6 +560,13 @@ class GrafanaSourceConsumer(Object):
         self.on.sources_changed.emit()  # pyright: ignore
         self.on.sources_to_delete_changed.emit()  # pyright: ignore
 
+    def _publish_source_uids(self, rel: Relation, uids: Dict[str, str]):
+        """Share the datasource UIDs back to the datasources.
+
+        Assumes only leader unit will call this method
+        """
+        rel.data[self._charm.app]["datasource_uids"] = json.dumps(uids)
+
     def _get_source_config(self, rel: Relation):
         """Generate configuration from data stored in relation data by providers."""
         source_data = json.loads(rel.data[rel.app].get("grafana_source_data", "{}"))  # type: ignore
@@ -588,6 +604,10 @@ class GrafanaSourceConsumer(Object):
                 sources_to_delete.remove(host_data["source_name"])
 
             data.append(host_data)
+
+        # share the unique source names back to the datasource units
+        self._publish_source_uids(rel, {ds["unit"]: ds["source_name"] for ds in data})
+
         self.set_peer_data("sources_to_delete", list(sources_to_delete))
         return data
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -429,13 +429,15 @@ class GrafanaSourceProvider(Object):
                 continue
             self._set_sources(rel)
 
-    def get_source_uids(self) -> Dict[Relation, Dict[str, str]]:
-        """Get the datasource UID(s) assigned by the remote end(s) to this datasource."""
+    def get_source_uids(self) -> Dict[str, Dict[str, str]]:
+        """Get the datasource UID(s) assigned by the remote end(s) to this datasource.
+
+        Returns a mapping from remote application names to unit names to datasource uids."""
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel] = json.loads(rel.data[rel.app]["datasource_uids"])
+            uids[rel.app.name] = json.loads(rel.data[rel.app]["datasource_uids"])
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -429,13 +429,13 @@ class GrafanaSourceProvider(Object):
                 continue
             self._set_sources(rel)
 
-    def get_source_uids(self) -> Dict[Relation, str]:
+    def get_source_uids(self) -> Dict[Relation, Dict[str, str]]:
         """Get the datasource UID(s) assigned by the remote end(s) to this datasource."""
         uids = {}
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel] = rel.data[rel.app]["datasource_uid"]
+            uids[rel] = json.loads(rel.data[rel.app]["datasource_uids"])
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -676,6 +676,12 @@ class GrafanaSourceConsumer(Object):
                     self._remove_source(host["source_name"])
 
             self.set_peer_data("sources", stored_sources)
+
+            # remove this datasource name from the published datasource names shared with the datasource units
+            self._publish_source_uids(
+                event.relation, {ds["unit"]: ds["source_name"] for ds in stored_sources[rel_id]}
+            )
+
             return True
         return False
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -677,7 +677,7 @@ class GrafanaSourceConsumer(Object):
 
             self.set_peer_data("sources", stored_sources)
 
-            # remove this datasource name from the published datasource names shared with the datasource units
+            # update this relation's shared datasource names after removing this unit/source
             self._publish_source_uids(
                 event.relation, {ds["unit"]: ds["source_name"] for ds in removed_source}
             )

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -679,7 +679,7 @@ class GrafanaSourceConsumer(Object):
 
             # remove this datasource name from the published datasource names shared with the datasource units
             self._publish_source_uids(
-                event.relation, {ds["unit"]: ds["source_name"] for ds in stored_sources[rel_id]}
+                event.relation, {ds["unit"]: ds["source_name"] for ds in removed_source}
             )
 
             return True

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -13,6 +13,7 @@ def tautology(*_, **__) -> bool:
 @pytest.fixture
 def ctx():
     patches = (
+        patch("charm.GrafanaCharm._push_sqlite_static", new=lambda _: None),
         patch("lightkube.core.client.GenericSyncClient"),
         patch("socket.getfqdn", new=lambda *args: "grafana-k8s-0.testmodel.svc.cluster.local"),
         patch("socket.gethostbyname", new=lambda *args: "1.2.3.4"),

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -1,0 +1,41 @@
+import json
+
+from ops.testing import Container, State
+from scenario import Relation, PeerRelation
+
+containers = [
+    Container(name="grafana", can_connect=True),
+    Container(name="litestream", can_connect=True),
+]
+
+
+def test_datasource_sharing(ctx):
+    # GIVEN a datasource relation with two remote units
+    datasource = Relation(
+        "grafana-source",
+        remote_app_name="remote_host",
+        remote_units_data={
+            0: {"grafana_source_host": "remote_host.0"},
+            1: {"grafana_source_host": "remote_host.1"},
+        },
+        remote_app_data={
+            "grafana_source_data": json.dumps(
+                {"model": "foo", "model_uuid": "bar", "application": "baz", "type": "tempo"}
+            )
+        },
+    )
+    state = State(
+        leader=True, containers=containers, relations={datasource, PeerRelation("grafana")}
+    )
+
+    # WHEN relation-changed fires for a datasource relation
+    out = ctx.run(ctx.on.relation_changed(datasource), state)
+
+    # THEN grafana shares back over the same relation a mapping of datasource uids
+    datasource_out = out.get_relation(datasource.id)
+    local_app_data = datasource_out.local_app_data
+    ds_uids = json.loads(local_app_data["datasource_uids"])
+    assert ds_uids == {
+        "remote_host/0": "juju_foo_bar_baz_0",
+        "remote_host/1": "juju_foo_bar_baz_1",
+    }

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -1,7 +1,10 @@
 import json
 
+from ops import CharmBase, Framework
 from ops.testing import Container, State
-from scenario import Relation, PeerRelation
+from scenario import Relation, PeerRelation, Context
+
+from charms.grafana_k8s.v0.grafana_source import GrafanaSourceProvider
 
 containers = [
     Container(name="grafana", can_connect=True),
@@ -39,3 +42,44 @@ def test_datasource_sharing(ctx):
         "remote_host/0": "juju_foo_bar_baz_0",
         "remote_host/1": "juju_foo_bar_baz_1",
     }
+
+def test_datasource_get():
+    # GIVEN a datasource relation with two remote units
+    local_ds_uids = {
+        "prometheus/0": "some-datasource-uid",
+        "prometheus/1": "some-datasource-uid",
+    }
+    datasource = Relation(
+        "grafana-source",
+        remote_app_name="remote_host",
+        local_unit_data={"grafana_source_host": "somehost:80"},
+        local_app_data={
+            "grafana_source_data": json.dumps(
+                {"model": "foo", "model_uuid": "bar", "application": "baz", "type": "tempo"}
+            )
+        },
+        remote_app_data={
+            "datasource_uids": json.dumps(local_ds_uids)
+        }
+    )
+    state = State(
+        leader=True, relations={datasource}
+    )
+
+    # WHEN relation-changed fires for a datasource relation
+    class MyProviderCharm(CharmBase):
+        META={"name":"edgar",
+              "provides":{"grafana-source": {"interface": "grafana_datasource"}}}
+
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            self.source_provider = GrafanaSourceProvider(self, "tempo",
+                                                         source_url="somehost",
+                                                         source_port="80")
+
+    ctx = Context(MyProviderCharm, MyProviderCharm.META)
+    with ctx(ctx.on.relation_changed(datasource), state) as mgr:
+        charm = mgr.charm
+        # THEN we can see our datasource uids via the provider
+        assert list(charm.source_provider.get_source_uids().values())[0] == local_ds_uids
+

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -43,6 +43,7 @@ def test_datasource_sharing(ctx):
         "remote_host/1": "juju_foo_bar_baz_1",
     }
 
+
 def test_datasource_get():
     # GIVEN a datasource relation with two remote units
     local_ds_uids = {
@@ -58,28 +59,25 @@ def test_datasource_get():
                 {"model": "foo", "model_uuid": "bar", "application": "baz", "type": "tempo"}
             )
         },
-        remote_app_data={
-            "datasource_uids": json.dumps(local_ds_uids)
-        }
+        remote_app_data={"datasource_uids": json.dumps(local_ds_uids)},
     )
-    state = State(
-        leader=True, relations={datasource}
-    )
+    state = State(leader=True, relations={datasource})
 
     # WHEN relation-changed fires for a datasource relation
     class MyProviderCharm(CharmBase):
-        META={"name":"edgar",
-              "provides":{"grafana-source": {"interface": "grafana_datasource"}}}
+        META = {
+            "name": "edgar",
+            "provides": {"grafana-source": {"interface": "grafana_datasource"}},
+        }
 
         def __init__(self, framework: Framework):
             super().__init__(framework)
-            self.source_provider = GrafanaSourceProvider(self, "tempo",
-                                                         source_url="somehost",
-                                                         source_port="80")
+            self.source_provider = GrafanaSourceProvider(
+                self, "tempo", source_url="somehost", source_port="80"
+            )
 
     ctx = Context(MyProviderCharm, MyProviderCharm.META)
     with ctx(ctx.on.relation_changed(datasource), state) as mgr:
         charm = mgr.charm
         # THEN we can see our datasource uids via the provider
         assert list(charm.source_provider.get_source_uids().values())[0] == local_ds_uids
-

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    pyright==1.1.316
+    pyright==1.1.389
     charm: -r{toxinidir}/requirements.txt
     lib: ops
     lib: jinja2


### PR DESCRIPTION
## Issue
The grafana source providers need to receive back from grafana the UIDs assigned to them. This, to support cross-referencing functionalities such as https://github.com/canonical/tempo-coordinator-k8s-operator/pull/77.

[Tandem PR in prometheus to forward this data to remote-write integrations](https://github.com/canonical/prometheus-k8s-operator/pull/647)

## Solution
added a `grafana_source_uids: Dict[unit_name: source_uid]` field to the application databag on the grafana side.

All changes are additive and therefore backwards-compatible.
