### PR TITLE
allow empty datasource_uids field without raising

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -162,7 +162,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 23
 
 logger = logging.getLogger(__name__)
 
@@ -438,7 +438,7 @@ class GrafanaSourceProvider(Object):
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel.app.name] = json.loads(rel.data[rel.app]["datasource_uids"])
+            uids[rel.app.name] = json.loads(rel.data[rel.app].get("datasource_uids","{}"))
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -438,7 +438,7 @@ class GrafanaSourceProvider(Object):
         for rel in self._charm.model.relations.get(self._relation_name, []):
             if not rel:
                 continue
-            uids[rel.app.name] = json.loads(rel.data[rel.app].get("datasource_uids","{}"))
+            uids[rel.app.name] = json.loads(rel.data[rel.app].get("datasource_uids", "{}"))
         return uids
 
     def _set_sources_from_event(self, event: RelationJoinedEvent) -> None:

--- a/tests/scenario/test_datasources.py
+++ b/tests/scenario/test_datasources.py
@@ -82,6 +82,7 @@ def test_datasource_get():
         # THEN we can see our datasource uids via the provider
         assert list(charm.source_provider.get_source_uids().values())[0] == local_ds_uids
 
+
 def test_datasource_get_nodata():
     # GIVEN a datasource relation with two remote units, but which hasn't shared any datasource uids
     datasource = Relation(


### PR DESCRIPTION
return an empty object instead of raising if the remote end uses an old interface