### PR TITLE
Automatically overwrite dashboard UIDs with a prescribed naming pattern, on the provider side

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -221,6 +221,8 @@ LIBAPI = 0
 
 LIBPATCH = 41
 
+PYDEPS = ["cosl >= 0.0.50"]
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/unit/dashboard_templates/first.tmpl
+++ b/tests/unit/dashboard_templates/first.tmpl
@@ -1,1 +1,1 @@
-test_first
+{"test": "first"}

--- a/tests/unit/dashboard_templates/other.json
+++ b/tests/unit/dashboard_templates/other.json
@@ -1,1 +1,1 @@
-test_second
+{"test": "second"}

--- a/tests/unit/manual_dashboards/manual.tmpl
+++ b/tests/unit/manual_dashboards/manual.tmpl
@@ -1,1 +1,1 @@
-test_manual
+{"test": "manual"}

--- a/tests/unit/test_dashboard_provider.py
+++ b/tests/unit/test_dashboard_provider.py
@@ -22,7 +22,7 @@ if "unittest.util" in __import__("sys").modules:
 RELATION_TEMPLATES_DATA = {
     "file:first": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQAKdGVzdF9maXJzdAoAAIC4BxCQe2GHAAEjC8Ib/QkftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBDeyJ0ZXN0IjogImZpcnN0IiwgInVpZCI6ICI0Zjg0NGIxNTc1NWUyZjQ1MmFkOWY5YTRhOTA2ZTVjNjEwODFhMmExIn0ASLsFcbMcmxMAAVxE+iI5Rx+2830BAAAAAARZWg==",
         "inject_dropdowns": True,
         "dashboard_alt_uid": "6291687b37603a46",
         "juju_topology": {
@@ -34,7 +34,7 @@ RELATION_TEMPLATES_DATA = {
     },
     "file:other": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQALdGVzdF9zZWNvbmQKAEby/qNFFKmEAAEkDKYY2NgftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBEeyJ0ZXN0IjogInNlY29uZCIsICJ1aWQiOiAiYzcxN2M3YzdjYjA5NjZiYjI0MTUwMmFhZTIzYzg2M2ZkNzI2NzhhYiJ9AAAAANxfFUoYy0r1AAFdRS0jJSkftvN9AQAAAAAEWVo=",
         "inject_dropdowns": True,
         "dashboard_alt_uid": "a44939b79a5ba1d4",
         "juju_topology": {
@@ -49,7 +49,7 @@ RELATION_TEMPLATES_DATA = {
 MANUAL_TEMPLATE_DATA = {
     "file:manual": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQALdGVzdF9tYW51YWwKAJN3IemeHXT1AAEkDKYY2NgftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBEeyJ0ZXN0IjogIm1hbnVhbCIsICJ1aWQiOiAiM2NjODI5ODY5MDI3YmQ1MzJiMmZiY2FkM2Y0ZDQ2ODk1M2Y2NzQxYyJ9AAAAAIUFL1o/OGdNAAFdRS0jJSkftvN9AQAAAAAEWVo=",
         "inject_dropdowns": True,
         "dashboard_alt_uid": "0b73d01f7b214e98",
         "juju_topology": {
@@ -65,7 +65,7 @@ MANUAL_TEMPLATE_DATA = {
 MANUAL_TEMPLATE_DATA_NO_DROPDOWNS = {
     "file:manual": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQALdGVzdF9tYW51YWwKAJN3IemeHXT1AAEkDKYY2NgftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBEeyJ0ZXN0IjogIm1hbnVhbCIsICJ1aWQiOiAiM2NjODI5ODY5MDI3YmQ1MzJiMmZiY2FkM2Y0ZDQ2ODk1M2Y2NzQxYyJ9AAAAAIUFL1o/OGdNAAFdRS0jJSkftvN9AQAAAAAEWVo=",
         "inject_dropdowns": False,
         "dashboard_alt_uid": "0b73d01f7b214e98",
         "juju_topology": {},

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    pyright==1.1.389
+    pyright
     charm: -r{toxinidir}/requirements.txt
     lib: ops
     lib: jinja2
@@ -66,7 +66,7 @@ allowlist_externals = /usr/bin/env
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
+    pytest
     coverage[toml]
     responses
     cosl
@@ -86,7 +86,7 @@ allowlist_externals =
 [testenv:scenario]
 description = Run scenario tests
 deps =
-    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
+    pytest
     responses
     cosl
     ops[testing]
@@ -109,7 +109,7 @@ deps =
     juju<=3.3.0,>=3.0
     # https://github.com/juju/python-libjuju/issues/1184
     websockets<14.0
-    pytest<8.2.0 # https://github.com/pytest-dev/pytest/issues/12263
+    pytest
     pytest-operator
     pytest-playwright
     lightkube

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ allowlist_externals =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest-asyncio==0.21.1
+    pytest-asyncio
     aiohttp
     asyncstdlib
     # Libjuju needs to track the juju version


### PR DESCRIPTION
## Issue
- https://github.com/canonical/observability/blob/main/decision-records/2024-08-29--dashboard-uid-collision.md


## Solution
Use shake_256 to generate a prescribed uid, overwriting any pre-existing uid.

In tandem with:
- https://github.com/canonical/cos-lib/pull/114
- https://github.com/canonical/grafana-agent-operator/pull/224
- https://github.com/canonical/grafana-agent-k8s-operator/pull/337
- https://github.com/canonical/cos-proxy-operator/pull/174

## Context
- Afaict, the only user of the `.add_dashboard` method is https://github.com/canonical/cos-registration-server-k8s-operator/blob/6e156f0b1367f7cc6ce12d89f6a367bf491fea7f/src/charm.py#L240.
- [Dahsboard templates](https://github.com/search?q=org%3Acanonical+path%3A.tmpl+grafana&type=code) ([example](https://github.com/canonical/cos-proxy-operator/blob/2835a6b79b30cc5272237f31ae2d1034859ee1a6/src/grafana_dashboards/impi-sensor.json.tmpl#L6)) are rendered on the consumer side (grafana itself). The templates themselves are still valid json, so it's ok to `json.loads` them in the provider side.

## Testing Instructions
First, prepare the charms locally: 
1. Copy the grafana_dashboard lib from this PR into grafana-agent-operator from https://github.com/canonical/grafana-agent-operator/pull/224.
2. Copy cos-agent lib from https://github.com/canonical/grafana-agent-operator/pull/224 into zookeeper.
3. In zookeeper, update deps using the following commands. Then remove all the `--hash` from requirements.txt:

```
poetry update
poetry lock
poetry install
poetry export -f requirements.txt --output requirements.tx
```

4. Pack and deploy all charms as follows:

```mermaid
graph LR
subgraph lxd
zookeeper --- grafana-agent
zookeeper2 --- grafana-agent
end
subgraph microk8s
grafana-agent --- grafana
end
```

```yaml
bundle: kubernetes
applications:
  graf:
    charm: ./grafana-k8s_ubuntu-20.04-amd64.charm
    scale: 1
    trust: true
--- # overlay.yaml
applications:
  graf:
    offers:
      graf:
        endpoints:
        - grafana-dashboard
        acl:
          admin: admin
```
```yaml
default-base: ubuntu@22.04/stable
saas:
  graf:
    url: microk8s:admin/graf.graf
applications:
  ga2:
    charm: ./grafana-agent_ubuntu-22.04-amd64.charm
  zk:
    charm: ./zookeeper_ubuntu-22.04-amd64.charm
    num_units: 2
  zk2:
    charm: ./zookeeper_ubuntu-22.04-amd64.charm
    num_units: 2
relations:
- - ga2:cos-agent
  - zk:cos-agent
- - ga2:cos-agent
  - zk2:cos-agent
- - ga2:grafana-dashboards-provider
  - graf:grafana-dashboard
```

## Upgrade Notes
- This change will break existing bookmarks to existing dashboards, because charms that fetch-lib this change would have the uid of all dashboards changed.
- If you have more than one app of the same charm deployed, they would all need to be refreshed together to avoid dashboard title collision. If you do not refresh all of them, grafana will output the following logs:
  - `dashboard title is not unique in folder`
  - `dashboards provisioning provider has no database write permissions because of duplicates`
  - `Not saving new dashboard due to restricted database access`

To enable automatic uid collision prevention for the dashboards in your charm:
1. If cos-lib (cosl) is pinned in your charm, bump it to 0.0.50 or higher.
2. Fetch-lib [cos-agent](https://charmhub.io/grafana-agent/libraries/cos_agent). You should use 0.13 or higher.
3. Refresh your charm.
4. Refresh grafana-agent to revision 369+.
