### PR TITLE
tests: relation_broken.emit() takes a relation, not a relation ID

### DIFF
--- a/tests/unit/test_source_consumer.py
+++ b/tests/unit/test_source_consumer.py
@@ -321,7 +321,8 @@ class TestSourceConsumer(unittest.TestCase):
             rel_id, "prometheus/0", {"grafana_source_host": "1.2.3.4:9090"}
         )
 
-        self.harness.charm.on["grafana-source"].relation_broken.emit(rel_id)
+        rel = self.harness.charm.framework.model.get_relation("grafana-source", rel_id)  # type: ignore
+        self.harness.charm.on["grafana-source"].relation_broken.emit(rel)
         self.assertEqual(self.harness.charm._stored.source_delete_events, 0)
         self.assertEqual(len(self.harness.charm.grafana_consumer.sources_to_delete), 0)
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

A broken test (not noticeable at the moment, although it's not doing the right thing, but noticeable with the snapshot changes in https://github.com/canonical/operator/pull/1372).

## Solution
<!-- A summary of the solution addressing the above issue -->

Pass the correct argument to `relation_broken.emit()`

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

ops?

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

`tox -e unit`

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A