### PR TITLE
fix: update cos-tool permissions to adhere to cis hardening rules

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -135,7 +135,7 @@ parts:
       - curl
     override-pull: |
       curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
-      chmod +x cos-tool-*
+      chmod 775 cos-tool-*
 
 actions:
   get-admin-password:

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -415,7 +415,8 @@ class RelationInterfaceMismatchError(Exception):
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
         self.message = (
-            "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
+            "The '{}' relation has '{}' as "
+            "interface rather than the expected '{}'".format(
                 relation_name, actual_relation_interface, expected_relation_interface
             )
         )

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 37
+LIBPATCH = 38
 
 logger = logging.getLogger(__name__)
 
@@ -1994,7 +1994,7 @@ class CosTool:
         res = "cos-tool-{}".format(arch)
         try:
             path = Path(res).resolve()
-            path.chmod(0o777)
+            path.chmod(0o775)
             return path
         except NotImplementedError:
             logger.debug("System lacks support for chmod")

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -415,8 +415,7 @@ class RelationInterfaceMismatchError(Exception):
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
         self.message = (
-            "The '{}' relation has '{}' as "
-            "interface rather than the expected '{}'".format(
+            "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
                 relation_name, actual_relation_interface, expected_relation_interface
             )
         )
@@ -1994,10 +1993,7 @@ class CosTool:
         res = "cos-tool-{}".format(arch)
         try:
             path = Path(res).resolve()
-            path.chmod(0o775)
             return path
-        except NotImplementedError:
-            logger.debug("System lacks support for chmod")
         except FileNotFoundError:
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -415,8 +415,7 @@ class RelationInterfaceMismatchError(Exception):
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
         self.message = (
-            "The '{}' relation has '{}' as "
-            "interface rather than the expected '{}'".format(
+            "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
                 relation_name, actual_relation_interface, expected_relation_interface
             )
         )
@@ -1993,9 +1992,9 @@ class CosTool:
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:
-            path = Path(res).resolve()
+            path = Path(res).resolve(strict=True)
             return path
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 


### PR DESCRIPTION
## Issue
Needed for the following PR: https://github.com/canonical/grafana-agent-operator/pull/231
More info on the CIS hardening rule can be found here[^1].


## Solution
Use `path.chmod(0o775)` in order to comply wit the CIS Hardening rules.

[^1]: https://github.com/canonical/grafana-agent-operator/issues/208