### PR TITLE
fix: set the correct permissions for cos-tool in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,7 @@ deps =
 commands =
     /usr/bin/env sh -c 'stat sqlite-static > /dev/null 2>&1 || curl -L https://github.com/CompuRoot/static-sqlite3/releases/latest/download/sqlite3 -o sqlite-static && chmod +x sqlite-static'
     /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64'
+    /usr/bin/env sh -c 'chmod 775 cos-tool-amd64'
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \
       -m pytest -v --tb native -s {posargs} {[vars]tst_path}/unit


### PR DESCRIPTION
This issue was not appearing before because we were running `chmod` in the charm libraries. Now that we removed that, we should fix it in `tox.ini`.