### PR TITLE
Use CRAFT_ARCH_BUILD_FOR

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -139,7 +139,7 @@ parts:
     build-packages:
       - curl
     override-pull: |
-      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
+      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_ARCH_BUILD_FOR}
       chmod 775 cos-tool-*
 
 actions:


### PR DESCRIPTION
## Issue
Deprecation warning [in CI](https://github.com/canonical/grafana-k8s-operator/actions/runs/12873740582/job/35893423553):
```
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
```


## Solution
Per recommendation.
