### PR TITLE
Address traceback on relation broken

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 38
+LIBPATCH = 39
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -1665,8 +1665,8 @@ class GrafanaDashboardConsumer(Object):
 
     def get_peer_data(self, key: str) -> Any:
         """Retrieve information from the peer data bucket instead of `StoredState`."""
-        if rel := self._charm.peers:
-            data = rel.data[self._charm.app].get(key, "")  # type: ignore[attr-defined]
+        if rel := self._charm.peers:  # type: ignore[attr-defined]
+            data = rel.data[self._charm.app].get(key, "")
             return json.loads(data) if data else {}
         return {}
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1665,8 +1665,10 @@ class GrafanaDashboardConsumer(Object):
 
     def get_peer_data(self, key: str) -> Any:
         """Retrieve information from the peer data bucket instead of `StoredState`."""
-        data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore[attr-defined]
-        return json.loads(data) if data else {}
+        if rel := self._charm.peers:
+            data = rel.data[self._charm.app].get(key, "")  # type: ignore[attr-defined]
+            return json.loads(data) if data else {}
+        return {}
 
 
 class GrafanaDashboardAggregator(Object):


### PR DESCRIPTION
## Issue
When grafana-k8s is removed, we sometimes see
```
    data = self._charm.peers.data[self._charm.app].get(key, "")
AttributeError: 'NoneType' object has no attribute 'data'
```


## Solution
Add a guard and return `{}` if the relation is None.

Fixes #365.

## Context
Full traceback:
```
unit-graf-0: 18:46:29 WARNING unit.graf/0.grafana-dashboard-relation-broken   main(GrafanaCharm, use_juju_for_storage=True)
unit-graf-0: 18:46:29 ERROR unit.graf/0.juju-log grafana-dashboard:29: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "./src/charm.py", line 1563, in <module>
    main(GrafanaCharm, use_juju_for_storage=True)
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/main.py", line 45, in main
    return _main.main(charm_class=charm_class, use_juju_for_storage=use_juju_for_storage)
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/_main.py", line 543, in main
    manager.run()
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/_main.py", line 529, in run
    self._emit()
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/_main.py", line 518, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name, self._juju_context)
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/_main.py", line 134, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/framework.py", line 347, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/framework.py", line 857, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-graf-0/charm/venv/ops/framework.py", line 947, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/grafana_k8s/v0/grafana_dashboard.py", line 1391, in _on_grafana_dashboard_relation_broken
    self._remove_all_dashboards_for_relation(event.relation)
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/grafana_k8s/v0/grafana_dashboard.py", line 1525, in _remove_all_dashboards_for_relation
    if self._get_stored_dashboards(relation.id):
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/grafana_k8s/v0/grafana_dashboard.py", line 1558, in _get_stored_dashboards
    return self.get_peer_data("dashboards").get(str(relation_id), {})
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 735, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-graf-0/charm/lib/charms/grafana_k8s/v0/grafana_dashboard.py", line 1573, in get_peer_data
    data = self._charm.peers.data[self._charm.app].get(key, "")  # type: ignore[attr-defined]
AttributeError: 'NoneType' object has no attribute 'data'
unit-graf-0: 18:46:30 ERROR juju.worker.uniter.operation hook "grafana-dashboard-relation-broken" (via hook dispatching script: dispatch) failed: exit status 1
```

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
