### PR TITLE
"Potentially" fix dashboards disappearing  

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 39
+LIBPATCH = 40
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -417,8 +417,7 @@ class RelationInterfaceMismatchError(Exception):
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
         self.message = (
-            "The '{}' relation has '{}' as "
-            "interface rather than the expected '{}'".format(
+            "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
                 relation_name, actual_relation_interface, expected_relation_interface
             )
         )
@@ -1601,7 +1600,7 @@ class GrafanaDashboardConsumer(Object):
 
         if not coerced_data == stored_data:
             stored_dashboards = self.get_peer_data("dashboards")
-            stored_dashboards[relation.id] = stored_data
+            stored_dashboards[str(relation.id)] = stored_data
             self.set_peer_data("dashboards", stored_dashboards)
             return True
         return None  # type: ignore

--- a/src/charm.py
+++ b/src/charm.py
@@ -211,7 +211,8 @@ class GrafanaCharm(CharmBase):
         # -- standard events
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
-            self.on.grafana_pebble_ready, self._on_pebble_ready  # pyright: ignore
+            self.on.grafana_pebble_ready,
+            self._on_pebble_ready,  # pyright: ignore
         )
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.stop, self._on_stop)
@@ -265,7 +266,8 @@ class GrafanaCharm(CharmBase):
             self, self.name, resource_reqs_func=self._resource_reqs_from_config
         )
         self.framework.observe(
-            self.resource_patch.on.patch_failed, self._on_resource_patch_failed  # pyright: ignore
+            self.resource_patch.on.patch_failed,
+            self._on_resource_patch_failed,  # pyright: ignore
         )
         # -- grafana_auth relation observations
         self.grafana_auth_requirer = AuthRequirer(
@@ -299,7 +301,8 @@ class GrafanaCharm(CharmBase):
 
         # -- cert_handler observations
         self.framework.observe(
-            self.cert_handler.on.cert_changed, self._on_server_cert_changed  # pyright: ignore
+            self.cert_handler.on.cert_changed,
+            self._on_server_cert_changed,  # pyright: ignore
         )
 
         # -- trusted_cert_transfer observations
@@ -316,10 +319,12 @@ class GrafanaCharm(CharmBase):
 
         # oauth relation observations
         self.framework.observe(
-            self.oauth.on.oauth_info_changed, self._on_oauth_info_changed  # pyright: ignore
+            self.oauth.on.oauth_info_changed,
+            self._on_oauth_info_changed,  # pyright: ignore
         )
         self.framework.observe(
-            self.oauth.on.oauth_info_removed, self._on_oauth_info_changed  # pyright: ignore
+            self.oauth.on.oauth_info_removed,
+            self._on_oauth_info_changed,  # pyright: ignore
         )
 
         # self.catalog = CatalogueConsumer(charm=self, item=self._catalogue_item)
@@ -413,7 +418,9 @@ class GrafanaCharm(CharmBase):
         litestream_config = {"addr": ":9876", "dbs": [{"path": DATABASE_PATH}]}
 
         if not leader:
-            litestream_config["dbs"][0].update({"upstream": {"url": "http://${LITESTREAM_UPSTREAM_URL}"}})  # type: ignore
+            litestream_config["dbs"][0].update(
+                {"upstream": {"url": "http://${LITESTREAM_UPSTREAM_URL}"}}
+            )  # type: ignore
 
         container = self.containers["replication"]
         if container.can_connect():
@@ -629,7 +636,7 @@ class GrafanaCharm(CharmBase):
         default_config = os.path.join(dashboard_path, "default.yaml")
         default_config_string = yaml.dump(dashboard_config)
 
-        if not os.path.exists(dashboard_path):
+        if not container.exists(dashboard_path):
             try:
                 container.push(default_config, default_config_string, make_dirs=True)
                 self.restart_grafana()
@@ -738,7 +745,8 @@ class GrafanaCharm(CharmBase):
 
         # Get required information
         database_fields = {
-            field: event.relation.data[event.app].get(field) for field in REQUIRED_DATABASE_FIELDS  # type: ignore
+            field: event.relation.data[event.app].get(field)
+            for field in REQUIRED_DATABASE_FIELDS  # type: ignore
         }
 
         # if any required fields are missing, warn the user and return
@@ -1131,13 +1139,13 @@ class GrafanaCharm(CharmBase):
                             "GF_LOG_LEVEL": cast(str, self.model.config["log_level"]),
                             "GF_PLUGINS_ENABLE_ALPHA": "true",
                             "GF_PATHS_PROVISIONING": PROVISIONING_PATH,
-                            "GF_SECURITY_ALLOW_EMBEDDING": cast(
-                                str, self.model.config["allow_embedding"]
+                            "GF_SECURITY_ALLOW_EMBEDDING": str(
+                                self.model.config["allow_embedding"]
                             ),
                             "GF_SECURITY_ADMIN_USER": cast(str, self.model.config["admin_user"]),
                             "GF_SECURITY_ADMIN_PASSWORD": self._get_admin_password(),
-                            "GF_AUTH_ANONYMOUS_ENABLED": cast(
-                                str, self.model.config["allow_anonymous_access"]
+                            "GF_AUTH_ANONYMOUS_ENABLED": str(
+                                self.model.config["allow_anonymous_access"]
                             ),
                             "GF_USERS_AUTO_ASSIGN_ORG": str(
                                 self.model.config["enable_auto_assign_org"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -1141,15 +1141,15 @@ class GrafanaCharm(CharmBase):
                             "GF_PATHS_PROVISIONING": PROVISIONING_PATH,
                             "GF_SECURITY_ALLOW_EMBEDDING": str(
                                 self.model.config["allow_embedding"]
-                            ),
+                            ).lower(),
                             "GF_SECURITY_ADMIN_USER": cast(str, self.model.config["admin_user"]),
                             "GF_SECURITY_ADMIN_PASSWORD": self._get_admin_password(),
                             "GF_AUTH_ANONYMOUS_ENABLED": str(
                                 self.model.config["allow_anonymous_access"]
-                            ),
+                            ).lower(),
                             "GF_USERS_AUTO_ASSIGN_ORG": str(
                                 self.model.config["enable_auto_assign_org"]
-                            ),
+                            ).lower(),
                             **extra_info,
                         },
                     }

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -524,7 +524,8 @@ class TestDashboardConsumer(unittest.TestCase):
 
         return rel_ids
 
-    def test_consumer_notifies_on_new_dashboards(self):
+    @patch("charm.GrafanaCharm.restart_grafana")
+    def test_consumer_notifies_on_new_dashboards(self, restart_patcher):
         self.assertEqual(len(self.harness.charm.grafana_consumer.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
         self.setup_charm_relations()
@@ -541,8 +542,11 @@ class TestDashboardConsumer(unittest.TestCase):
                 }
             ],
         )
+        # assert restart is not called
+        assert restart_patcher.call_count == 0
 
-    def test_consumer_notifies_on_new_dashboards_without_dropdowns(self):
+    @patch("charm.GrafanaCharm.restart_grafana")
+    def test_consumer_notifies_on_new_dashboards_without_dropdowns(self, restart_patcher):
         self.assertEqual(len(self.harness.charm.grafana_consumer.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
         self.setup_without_dropdowns(DASHBOARD_TEMPLATE)
@@ -559,6 +563,8 @@ class TestDashboardConsumer(unittest.TestCase):
                 }
             ],
         )
+        # assert restart is not called
+        assert restart_patcher.call_count == 0
 
     def test_consumer_error_on_bad_json(self):
         self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)


### PR DESCRIPTION
## Issue
Potentially fix intermittent issues where dashboards disappear or still exist after relation removal. 
https://github.com/canonical/cos-proxy-operator/issues/160
https://github.com/canonical/grafana-k8s-operator/issues/344
https://github.com/canonical/grafana-k8s-operator/issues/312

## Solution
- Remove unnecessary grafana restarts that happened with lots of events by:
  - casting pebble env variable as a string instead of a bool.
  - checking the path inside the workload container instead of the charm container.
- Fix duplicate dashboard entry in peer data
 
## Context
[cos-agent fix](https://github.com/canonical/grafana-agent-operator/pull/253)

