### PR TITLE
refactor: move the grafana UID definition to the charm from grafana_source

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -512,7 +512,7 @@ class GrafanaSourceConsumer(Object):
         Args:
             charm: a :class:`CharmBase` instance that manages this
                 instance of the Grafana source service.
-            grafana_uid: a unique identifier for this Grafana datasource.
+            grafana_uid: an identifier uniquely identifying this grafana-k8s application.
             relation_name: string name of the relation that is provides the
                 Grafana source service. It is strongly advised not to change
                 the default, so that people deploying your charm will have a

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -512,7 +512,7 @@ class GrafanaSourceConsumer(Object):
         Args:
             charm: a :class:`CharmBase` instance that manages this
                 instance of the Grafana source service.
-            grafana_uid: an identifier uniquely identifying this grafana-k8s application.
+            grafana_uid: an unique identifier for this grafana-k8s application.
             relation_name: string name of the relation that is provides the
                 Grafana source service. It is strongly advised not to change
                 the default, so that people deploying your charm will have a

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -162,7 +162,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 24
+LIBPATCH = 25
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/grafana_k8s/v0/grafana_source.py
+++ b/lib/charms/grafana_k8s/v0/grafana_source.py
@@ -504,6 +504,7 @@ class GrafanaSourceConsumer(Object):
     def __init__(
         self,
         charm: CharmBase,
+        grafana_uid: str,
         relation_name: str = DEFAULT_RELATION_NAME,
     ) -> None:
         """A Grafana based Monitoring service consumer, i.e., the charm that uses a datasource.
@@ -511,6 +512,7 @@ class GrafanaSourceConsumer(Object):
         Args:
             charm: a :class:`CharmBase` instance that manages this
                 instance of the Grafana source service.
+            grafana_uid: a unique identifier for this Grafana datasource.
             relation_name: string name of the relation that is provides the
                 Grafana source service. It is strongly advised not to change
                 the default, so that people deploying your charm will have a
@@ -524,6 +526,7 @@ class GrafanaSourceConsumer(Object):
         super().__init__(charm, relation_name)
         self._relation_name = relation_name
         self._charm = charm
+        self._grafana_uid = grafana_uid
         events = self._charm.on[relation_name]
 
         # We're stuck with this forever now so upgrades work, or until such point as we can
@@ -577,14 +580,7 @@ class GrafanaSourceConsumer(Object):
 
         Assumes only leader unit will call this method
         """
-        unique_grafana_name = "juju_{}_{}_{}_{}".format(
-            self._charm.model.name,
-            self._charm.model.uuid,
-            self._charm.model.app.name,
-            self._charm.model.unit.name.split("/")[1],  # type: ignore
-        )
-
-        rel.data[self._charm.app]["grafana_uid"] = unique_grafana_name
+        rel.data[self._charm.app]["grafana_uid"] = self._grafana_uid
         rel.data[self._charm.app]["datasource_uids"] = json.dumps(uids)
 
     def _get_source_config(self, rel: Relation):

--- a/src/charm.py
+++ b/src/charm.py
@@ -222,7 +222,7 @@ class GrafanaCharm(CharmBase):
         )
 
         # -- grafana_source relation observations
-        self.source_consumer = GrafanaSourceConsumer(self, "grafana-source")
+        self.source_consumer = GrafanaSourceConsumer(self, grafana_uid=self.unique_name, relation_name="grafana-source")
         self.framework.observe(
             self.source_consumer.on.sources_changed,  # pyright: ignore
             self._on_grafana_source_changed,
@@ -1621,6 +1621,16 @@ class GrafanaCharm(CharmBase):
             Path("sqlite-static").read_bytes(),
             permissions=0o755,
             make_dirs=True,
+        )
+
+    @property
+    def unique_name(self):
+        """Returns a unique identifier for this application."""
+        return "juju_{}_{}_{}_{}".format(
+            self.model.name,
+            self.model.uuid,
+            self.model.app.name,
+            self.model.unit.name.split("/")[1],  # type: ignore
         )
 
 


### PR DESCRIPTION
The grafana_source relation sends a unique string identifying this grafana.  Previously, this string was created in the grafana_source library, making it a bit awkward to use in other libraries.

This PR proposes a change where this identifier is created/owned by the grafana charm rather than the datasource lib.  Outwardly, this should cause no change in function.  The motivation for this change is to use this same identifier in the forthcoming grafana-metadata relation

The grafana_uid is meant for identifying an application of charmed grafana, so it should be universally unique (unique even across different models, deployments, etc).  Given that, it really is owned by grafana the application, and the related lib merely *uses* that ID.  

This change introduces a breaking change in the library API due to an additional required parameter.  The libapi has not been bumped here because grafana-k8s is the only operator that consumes this (and because, if there is someone else consuming it, the change in api will result in an obvious bug rather than a hidden bug, so the risk of real damage is low).  

## Testing Instructions
Should be covered by existing CI, apart from a slight fix in unit tests

## Upgrade Notes
Should not have any functional effect on the charm 