### PR TITLE
Fix broken Nrpe dashboard

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 39
+LIBPATCH = 40
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -417,8 +417,7 @@ class RelationInterfaceMismatchError(Exception):
         self.expected_relation_interface = expected_relation_interface
         self.actual_relation_interface = actual_relation_interface
         self.message = (
-            "The '{}' relation has '{}' as "
-            "interface rather than the expected '{}'".format(
+            "The '{}' relation has '{}' as " "interface rather than the expected '{}'".format(
                 relation_name, actual_relation_interface, expected_relation_interface
             )
         )
@@ -634,7 +633,10 @@ class CharmedDashboard:
         deletions = []
         for tmpl in dict_content["templating"]["list"]:
             if tmpl["name"] and tmpl["name"] in used_replacements:
-                deletions.append(tmpl)
+                # it might happen that existing template var name is the same as the one we insert (i.e prometheusds or lokids)
+                # in that case, we want to pop the existing one only.
+                if tmpl not in DATASOURCE_TEMPLATE_DROPDOWNS:
+                    deletions.append(tmpl)
 
         for d in deletions:
             dict_content["templating"]["list"].remove(d)

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 40
+LIBPATCH = 41
 
 PYDEPS = ["cosl >= 0.0.50"]
 


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/cos-proxy-operator/issues/179

## Solution
In case the existing template has a datasource variable with the same name of the ones we insert (i.e prometheusds/lokids), keep ours and delete theirs.


## Testing Instructions
In a k8s model, WITH THIS GRAFANA
```
bundle: kubernetes
saas:
  remote-1ca427cd89c949128b51f0cb99689105: {}
applications:
  grafana:
    charm: grafana-k8s
    channel: latest/edge
    revision: 135
    resources:
      grafana-image: 70
      litestream-image: 45
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: latest/edge
    revision: 185
    resources:
      loki-image: 100
      node-exporter-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: latest/edge
    revision: 229
    resources:
      prometheus-image: 151
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
relations:
- - prometheus:grafana-source
  - grafana:grafana-source
- - grafana:grafana-dashboard
  - remote-1ca427cd89c949128b51f0cb99689105:grafana-dashboards-provider
- - loki:grafana-source
  - grafana:grafana-source
--- # overlay.yaml
applications:
  grafana:
    offers:
      grafana:
        endpoints:
        - grafana-dashboard
        acl:
          admin: admin
  prometheus:
    offers:
      prometheus:
        endpoints:
        - receive-remote-write
        acl:
          admin: admin
```

In a machine model,
```
default-base: ubuntu@20.04/stable
saas:
  grafana:
    url: micro3:admin/test.grafana
applications:
  cos-proxy:
    charm: cos-proxy
    channel: latest/stable
    revision: 118
    num_units: 1
    to:
    - "6"
    constraints: arch=amd64
  grafana-agent:
    charm: grafana-agent
    channel: latest/stable
    revision: 366
  nrpe:
    charm: nrpe
    channel: latest/stable
    revision: 141
machines:
  "6":
    constraints: arch=amd64
relations:
- - nrpe:general-info
  - cos-proxy:juju-info
- - nrpe:monitors
  - cos-proxy:monitors
- - grafana:grafana-dashboard
  - grafana-agent:grafana-dashboards-provider
- - grafana-agent:cos-agent
  - cos-proxy:cos-agent
```

Open the grafana UI, then the NRPE dashboard, you should see a working dashboard like this
![image](https://github.com/user-attachments/assets/c81b4372-43c1-4e79-a253-2127b6945aac)

