### PR TITLE
Add tag with charm name to dashboard

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 41
+LIBPATCH = 42
 
 PYDEPS = ["cosl >= 0.0.50"]
 

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -965,6 +965,13 @@ class CharmedDashboard:
             )
 
     @classmethod
+    def _add_tags(cls, dashboard_dict: dict, charm_name: str):
+        tags: List[str] = dashboard_dict.get("tags", [])
+        if not any(tag.startswith("charm: ") for tag in tags):
+            tags.append(f"charm: {charm_name}")
+        dashboard_dict["tags"] = tags
+
+    @classmethod
     def load_dashboards_from_dir(
         cls,
         *,
@@ -1005,6 +1012,8 @@ class CharmedDashboard:
                 charm_dir=charm_dir,
                 charm_name=charm_name,
             )
+
+            cls._add_tags(dashboard_dict=dashboard_dict, charm_name=charm_name)
 
             id = "file:{}".format(path.stem)
             dashboard_templates[id] = cls._content_to_dashboard_object(

--- a/tests/unit/test_charmed_dashboard.py
+++ b/tests/unit/test_charmed_dashboard.py
@@ -1,0 +1,38 @@
+import unittest
+from charms.grafana_k8s.v0.grafana_dashboard import CharmedDashboard
+
+
+class CharmedDashboardTest(unittest.TestCase):
+    def test_add_tags_to_dashboard_without_tags(self):
+        # GIVEN a dashboard dict with no tags
+        dashboard = {}
+
+        # WHEN tags are added
+        CharmedDashboard._add_tags(dashboard, "my-charm")
+
+        # THEN list of tags only contains MyCharm
+        self.assertListEqual(dashboard["tags"], ["charm: my-charm"])
+
+    def test_add_tags_to_dashboard_with_tags(self):
+        # GIVEN a dashboard dict with some tags
+        dashboard = {"tags": ["one", "two"]}
+
+        # WHEN tags are added
+        CharmedDashboard._add_tags(dashboard, "my-charm")
+
+        # THEN list of tags is extended with MyCharm
+        self.assertListEqual(dashboard["tags"], ["one", "two", "charm: my-charm"])
+
+    def test_add_tags_to_dashboard_with_charm_tag(self):
+        # GIVEN a dashboard dict with a tag that starts with "charm: "
+        dashboard = {"tags": ["charm: something-else"]}
+
+        # WHEN tags are added
+        CharmedDashboard._add_tags(dashboard, "my-charm")
+
+        # THEN list of tags is unaffected
+        self.assertListEqual(dashboard["tags"], ["charm: something-else"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_dashboard_provider.py
+++ b/tests/unit/test_dashboard_provider.py
@@ -22,7 +22,7 @@ if "unittest.util" in __import__("sys").modules:
 RELATION_TEMPLATES_DATA = {
     "file:first": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBDeyJ0ZXN0IjogImZpcnN0IiwgInVpZCI6ICI0Zjg0NGIxNTc1NWUyZjQ1MmFkOWY5YTRhOTA2ZTVjNjEwODFhMmExIn0ASLsFcbMcmxMAAVxE+iI5Rx+2830BAAAAAARZWg==",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+Wj4ABnAGFdAD2IioaUXFVrEu9eEJyRf99sCsBItFjkmWby27QUlLkEOLcnhduY4+mCN01d1q200x5gz1Apuivvaa7GnxNV4yiVBn3QjP2OBr0vK+YIyoLqYOFFTVApImfM8MR4BO6WQAAAAAAAZwA0Rx1MbSEAAX1o+lt++R+2830BAAAAAARZWg==",
         "inject_dropdowns": True,
         "dashboard_alt_uid": "6291687b37603a46",
         "juju_topology": {
@@ -34,7 +34,7 @@ RELATION_TEMPLATES_DATA = {
     },
     "file:other": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBEeyJ0ZXN0IjogInNlY29uZCIsICJ1aWQiOiAiYzcxN2M3YzdjYjA5NjZiYjI0MTUwMmFhZTIzYzg2M2ZkNzI2NzhhYiJ9AAAAANxfFUoYy0r1AAFdRS0jJSkftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+Wj4ABoAGJdAD2IioaUXFVrEu9eFYCcHnOClmJwFGpUF9+f4scQVLIVh0dGRthp7VR8CepwuMuYM/ENRpca4OEO01DyoSAoNKyvNYzdITZDhBzuG6/HGZIDoZL34cJn3QP2kFr4HMRCtAAAAAAAmGsLclsH64QAAX5przhUpR+2830BAAAAAARZWg==",
         "inject_dropdowns": True,
         "dashboard_alt_uid": "a44939b79a5ba1d4",
         "juju_topology": {
@@ -49,7 +49,7 @@ RELATION_TEMPLATES_DATA = {
 MANUAL_TEMPLATE_DATA = {
     "file:manual": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBEeyJ0ZXN0IjogIm1hbnVhbCIsICJ1aWQiOiAiM2NjODI5ODY5MDI3YmQ1MzJiMmZiY2FkM2Y0ZDQ2ODk1M2Y2NzQxYyJ9AAAAAIUFL1o/OGdNAAFdRS0jJSkftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+Wj4ABoAGRdAD2IioaUXFVrEu9eEzLJAYcoJaoKeAoA9UD/AQKJqydHHoSE4tSLR65Xmqkzo/Sw/nNZImWBh5mIcpaLjVmjkrOlu9xza7tlno4m4n26CTdZOjfkAc3UD48RvzIVxS7j8POwIAAAEJtP70FL2ooAAYABaQAAADxRq6axxGf7AgAAAAAEWVo=",
         "inject_dropdowns": True,
         "dashboard_alt_uid": "0b73d01f7b214e98",
         "juju_topology": {
@@ -65,7 +65,7 @@ MANUAL_TEMPLATE_DATA = {
 MANUAL_TEMPLATE_DATA_NO_DROPDOWNS = {
     "file:manual": {
         "charm": "provider-tester",
-        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQBEeyJ0ZXN0IjogIm1hbnVhbCIsICJ1aWQiOiAiM2NjODI5ODY5MDI3YmQ1MzJiMmZiY2FkM2Y0ZDQ2ODk1M2Y2NzQxYyJ9AAAAAIUFL1o/OGdNAAFdRS0jJSkftvN9AQAAAAAEWVo=",
+        "content": "/Td6WFoAAATm1rRGAgAhARYAAAB0L+Wj4ABoAGRdAD2IioaUXFVrEu9eEzLJAYcoJaoKeAoA9UD/AQKJqydHHoSE4tSLR65Xmqkzo/Sw/nNZImWBh5mIcpaLjVmjkrOlu9xza7tlno4m4n26CTdZOjfkAc3UD48RvzIVxS7j8POwIAAAEJtP70FL2ooAAYABaQAAADxRq6axxGf7AgAAAAAEWVo=",
         "inject_dropdowns": False,
         "dashboard_alt_uid": "0b73d01f7b214e98",
         "juju_topology": {},


### PR DESCRIPTION
## Issue
- Sometimes it's not obvious where a given dashboard originated from.
- When browsing list of dashboards in grafana UI, it could be handy to filter by charm name.


## Solution
Have the Provider auto-add a tag with the charm's name, if it is not already there.
In tandem with https://github.com/canonical/grafana-agent-operator/pull/256.

Fixes #368.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
See https://github.com/canonical/grafana-agent-operator/pull/256.


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
