### PR TITLE
Backport to track/2: OBC-1398 Provision only the latest version per dashboard UID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build
 *.charm
 .idea
 __pycache__
+*.egg-info/
 .venv
 .tox
 .coverage

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
+from typing import List, Dict
 
 class FakeProcessVersionCheck:
     def __init__(self, args):
@@ -11,3 +13,10 @@ class FakeProcessVersionCheck:
 
     def wait(self):
         return
+
+
+def conv_dashboard_list(dashboards: List[Dict]) -> str:
+    # For diff purposes, replace contents (str) with parsed dashboard (dict)
+    # so that order of keys won't fail the str comparison.
+    # Then dump to pretty string so diff is easier to sift through
+    return json.dumps([{**d, **{"content": json.loads(d["content"])}} for d in dashboards], sort_keys=True, indent=2)

--- a/tests/unit/test_dashboard_collision.py
+++ b/tests/unit/test_dashboard_collision.py
@@ -1,0 +1,254 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+from typing import Any, Dict
+from pathlib import Path
+from cosl import LZMABase64
+from ops.testing import Context, PeerRelation, State
+
+
+def read_dashboards_from_fs(fs: Path) -> Dict[str, str]:
+    """Read dashboard files from the simulated filesystem.
+
+    Args:
+        fs: The filesystem object (from container.get_filesystem(ctx))
+        glob_pattern: Pattern to match dashboard files
+
+    Returns:
+        A mapping from relative filename to the contents of the file
+    """
+    dashboards_dir: Path = fs / "etc" / "grafana" / "provisioning" / "dashboards"
+    return {f.name: f.read_text() for f in dashboards_dir.glob("juju_*.json")}
+
+
+def dashboard_factory(
+    uid: str,
+    version: int,
+    relation_id: str = "1",
+    content: str = "test content"
+) -> Dict[str, Any]:
+    """Factory function for generating dashboard stand-in dictionaries.
+
+    Args:
+        uid: Dashboard UID
+        version: Dashboard version number
+        relation_id: Relation ID this dashboard belongs to (as string)
+        content: Dashboard content (default: "test content")
+
+    Returns:
+        A dictionary structure representing stored dashboard data in peer relation
+    """
+    dashboard_dict = {
+        "uid": uid,
+        "version": version,
+        "title": f"Test Dashboard {uid} - {content}",  # Use title for uniqueness
+        "panels": [],
+    }
+
+    dashboard_json = json.dumps(dashboard_dict)
+    compressed_content = LZMABase64.compress(dashboard_json)
+
+    # Return the structure as stored in peer data by GrafanaDashboardConsumer
+    # This matches the structure created in _render_dashboards_and_signal_changed
+    return {
+        "id": f"grafana-dashboard:{relation_id}/dashboard-{uid}",
+        "original_id": f"dashboard-{uid}",
+        "content": compressed_content,
+        "template": {
+            "charm": "test-charm",
+            "content": compressed_content,
+        },
+    }
+
+
+def test_distinct_uid_and_version_both_on_disk(ctx: Context, base_state: State):
+    """Test that two dashboards with distinct uid and version are both provisioned."""
+    # GIVEN reldata with two dashboard "objects" with distinct 'uid' and 'version'
+    dashboard1 = dashboard_factory(uid="dash1", version=1)
+    dashboard2 = dashboard_factory(uid="dash2", version=2)
+    peer_data = {
+        "dashboards": json.dumps({
+            "1": [dashboard1, dashboard2]
+        })
+    }
+    peer_relation_with_data = PeerRelation(
+        "grafana",
+        local_app_data=peer_data
+    )
+
+    # WHEN the charm processes the dashboards
+    state = State(
+        leader=True,
+        containers=base_state.containers,
+        relations={peer_relation_with_data}
+    )
+    out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN both dashboards should be written to the filesystem
+    container = out.get_container("grafana")
+    fs = container.get_filesystem(ctx)
+    dashboards = read_dashboards_from_fs(fs)
+
+    assert len(dashboards) == 2
+
+    # Verify the dashboards have the correct UIDs
+    dashboard_contents = [json.loads(content) for content in dashboards.values()]
+    dashboard_uids = {d["uid"] for d in dashboard_contents}
+    assert dashboard_uids == {"dash1", "dash2"}
+
+
+def test_distinct_uid_same_version_both_on_disk(ctx: Context, base_state: State):
+    """Test that two dashboards with distinct uid but same version are both provisioned."""
+    # GIVEN reldata with two dashboard "objects" with distinct 'uid' but same 'version'
+    dashboard1 = dashboard_factory(uid="dash1", version=1)
+    dashboard2 = dashboard_factory(uid="dash2", version=1)
+    peer_data = {
+        "dashboards": json.dumps({
+            "1": [dashboard1, dashboard2]
+        })
+    }
+    peer_relation_with_data = PeerRelation(
+        "grafana",
+        local_app_data=peer_data
+    )
+
+    # WHEN the charm processes the dashboards
+    state = State(
+        leader=True,
+        containers=base_state.containers,
+        relations={peer_relation_with_data}
+    )
+    out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN both dashboards should be written to the filesystem
+    container = out.get_container("grafana")
+    fs = container.get_filesystem(ctx)
+    dashboards = read_dashboards_from_fs(fs)
+
+    assert len(dashboards) == 2
+
+    # Verify the dashboards have the correct UIDs
+    dashboard_contents = [json.loads(content) for content in dashboards.values()]
+    dashboard_uids = {d["uid"] for d in dashboard_contents}
+    assert dashboard_uids == {"dash1", "dash2"}
+
+
+def test_same_uid_different_version_only_higher_on_disk(ctx: Context, base_state: State):
+    """Test that only the dashboard with higher version is provisioned when uid matches."""
+    # GIVEN reldata with two dashboard "objects" with the same 'uid' but different 'version'
+    dashboard1 = dashboard_factory(uid="dash1", version=1)
+    dashboard2 = dashboard_factory(uid="dash1", version=2)
+    peer_data = {
+        "dashboards": json.dumps({
+            "1": [dashboard1, dashboard2]
+        })
+    }
+    peer_relation_with_data = PeerRelation(
+        "grafana",
+        local_app_data=peer_data
+    )
+
+    # WHEN the charm processes the dashboards
+    state = State(
+        leader=True,
+        containers=base_state.containers,
+        relations={peer_relation_with_data}
+    )
+    out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN only one dashboard should be written to the filesystem - the one with higher version
+    container = out.get_container("grafana")
+    fs = container.get_filesystem(ctx)
+    dashboards = read_dashboards_from_fs(fs)
+
+    assert len(dashboards) == 1
+
+    # Verify the dashboard has the correct UID and version
+    dashboard_content = json.loads(list(dashboards.values())[0])
+    assert dashboard_content["uid"] == "dash1"
+    assert dashboard_content["version"] == 2
+
+
+def test_same_uid_same_version_deterministic_selection(ctx: Context, base_state: State):
+    """Test deterministic selection when uid and version are the same."""
+    # GIVEN reldata with two dashboard "objects" with the same 'uid' and same 'version'
+    dashboard1 = dashboard_factory(uid="dash1", version=1, content="content_a")
+    dashboard2 = dashboard_factory(uid="dash1", version=1, content="content_b")
+
+    # Set up peer relation with dashboards from different relations
+    peer_data = {
+        "dashboards": json.dumps({
+            "1": [dashboard1],
+            "2": [dashboard2]
+        })
+    }
+    peer_relation_with_data = PeerRelation(
+        "grafana",
+        local_app_data=peer_data
+    )
+
+    # WHEN the charm processes the dashboards
+    state = State(
+        leader=True,
+        containers=base_state.containers,
+        relations={peer_relation_with_data}
+    )
+    out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN only one dashboard should be written to the filesystem
+    # Selected deterministically based on (version, relation_id, content) lexicographic order
+    container = out.get_container("grafana")
+    fs = container.get_filesystem(ctx)
+    dashboards = read_dashboards_from_fs(fs)
+
+    assert len(dashboards) == 1
+
+    # Verify the dashboard has the correct UID and version
+    dashboard_content = json.loads(list(dashboards.values())[0])
+    assert dashboard_content["uid"] == "dash1"
+    assert dashboard_content["version"] == 1
+    # The one with higher relation_id (and different content) should win
+    assert "content_b" in dashboard_content["title"]
+
+
+def test_dashboard_with_missing_uid_is_omitted(ctx: Context, base_state: State):
+    """Test that dashboards missing a UID are omitted and not written to the filesystem."""
+    # GIVEN reldata with two dashboard "objects" where one of them is missing a 'uid'
+    dashboard1 = dashboard_factory(uid="dash1", version=1, content="content_a")
+    dashboard2 = dashboard_factory(uid="", version=2, content="content_b")
+    dashboard3 = dashboard_factory(uid=" ", version=3, content="content_c")
+
+    # Set up peer relation with dashboards from different relations
+    peer_data = {
+        "dashboards": json.dumps({
+            "1": [dashboard1, dashboard2, dashboard3],
+        })
+    }
+    peer_relation_with_data = PeerRelation(
+        "grafana",
+        local_app_data=peer_data
+    )
+
+    # WHEN the charm processes the dashboards
+    state = State(
+        leader=True,
+        containers=base_state.containers,
+        relations={peer_relation_with_data}
+    )
+    out = ctx.run(ctx.on.update_status(), state)
+
+    # THEN only one dashboard should be written to the filesystem
+    # Selected deterministically based on (version, relation_id, content) lexicographic order
+    container = out.get_container("grafana")
+    fs = container.get_filesystem(ctx)
+    dashboards = read_dashboards_from_fs(fs)
+
+    assert len(dashboards) == 1
+
+    # Verify the dashboard has the correct UID and version
+    dashboard_content = json.loads(list(dashboards.values())[0])
+    assert dashboard_content["uid"] == "dash1"
+    assert dashboard_content["version"] == 1
+    # The one with higher relation_id (and different content) should win
+    assert "content_a" in dashboard_content["title"]

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -8,6 +8,7 @@ import unittest
 import uuid
 from unittest.mock import patch
 
+from helpers import conv_dashboard_list
 from charms.grafana_k8s.v0.grafana_dashboard import (
     DATASOURCE_TEMPLATE_DROPDOWNS,
     TOPOLOGY_TEMPLATE_DROPDOWNS,
@@ -28,7 +29,8 @@ DASHBOARD_TEMPLATE = """
 {
     "panels": {
         "data": "label_values(up, juju_unit)"
-    }
+    },
+    "uid": "deadbeef"
 }
 """
 
@@ -46,6 +48,7 @@ DASHBOARD_DATA = {
 DASHBOARD_RENDERED = json.dumps(
     {
         "panels": {"data": "label_values(up, juju_unit)"},
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -55,6 +58,7 @@ DASHBOARD_RENDERED_NO_DROPDOWNS = json.dumps(
     {
         "panels": {"data": "label_values(up, juju_unit)"},
         "templating": {"list": list(DATASOURCE_TEMPLATE_DROPDOWNS)},
+        "uid": "deadbeef",
     }
 )
 
@@ -71,7 +75,8 @@ VARIABLE_DASHBOARD_TEMPLATE = """
             "data": "label_values(up, juju_unit)",
             "datasource": "$replace_me"
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -80,6 +85,7 @@ VARIABLE_DASHBOARD_RENDERED = json.dumps(
         "panels": [
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -103,7 +109,8 @@ ROW_ONLY_DASHBOARD_TEMPLATE = """
                 }
             ]
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -121,6 +128,7 @@ ROW_ONLY_DASHBOARD_RENDERED = json.dumps(
                 ],
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -141,7 +149,8 @@ INPUT_DASHBOARD_TEMPLATE = """
             "data": "label_values(up, juju_unit)",
             "datasource": "$DS_PROMETHEUS"
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -150,6 +159,7 @@ INPUT_DASHBOARD_RENDERED = json.dumps(
         "panels": [
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -165,7 +175,8 @@ NULL_DATASOURCE_DASHBOARD_TEMPLATE = """
             "data": "Row separator",
             "datasource": null
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -175,6 +186,7 @@ NULL_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
             {"data": "Row separator", "datasource": None},
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -203,7 +215,8 @@ BUILTIN_DATASOURCE_DASHBOARD_TEMPLATE = """
             ],
             "title": "foo"
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -220,6 +233,7 @@ BUILTIN_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
                 "title": "foo",
             }
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -240,6 +254,7 @@ EXISTING_VARIABLE_DASHBOARD_TEMPLATE = """
             "datasource": "${leave_me_alone}"
         }
     ],
+    "uid": "deadbeef",
     "templating": {
         "list": [
             {
@@ -269,6 +284,7 @@ EXISTING_VARIABLE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_application)", "datasource": "${prometheusds}"},
             {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
         ],
+        "uid": "deadbeef",
         "templating": {
             "list": list(reversed(TEMPLATE_DROPDOWNS))
             + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
@@ -288,6 +304,7 @@ EXISTING_DATASOURCE_DASHBOARD_TEMPLATE = """
             "datasource": "${leave_me_alone}"
         }
     ],
+    "uid": "deadbeef",
     "templating": {
         "list": [
             {
@@ -321,6 +338,7 @@ EXISTING_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${prometheusds}"},
             {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
         ],
+        "uid": "deadbeef",
         "templating": {
             "list": list(reversed(TEMPLATE_DROPDOWNS))
             + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
@@ -340,6 +358,7 @@ EXISTING_LOKI_DATASOURCE_DASHBOARD_TEMPLATE = """
             "datasource": "${leave_me_alone}"
         }
     ],
+    "uid": "deadbeef",
     "templating": {
         "list": [
             {
@@ -373,6 +392,7 @@ EXISTING_LOKI_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
             {"data": "label_values(up, juju_unit)", "datasource": "${lokids}"},
             {"data": "label_values(up, juju_unit)", "datasource": "${leave_me_alone}"},
         ],
+        "uid": "deadbeef",
         "templating": {
             "list": list(reversed(TEMPLATE_DROPDOWNS))
             + [{"name": "leave_me_alone", "query": "influxdb", "type": "datasource"}]
@@ -390,7 +410,8 @@ DICT_DATASOURCE_DASHBOARD_TEMPLATE = """
                 "uid": "someuid"
             }
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -405,6 +426,7 @@ DICT_DATASOURCE_DASHBOARD_RENDERED = json.dumps(
                 },
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -532,15 +554,18 @@ class TestDashboardConsumer(unittest.TestCase):
         self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
 
         self.assertEqual(
-            self.harness.charm.grafana_consumer.dashboards,
-            [
+            conv_dashboard_list(self.harness.charm.grafana_consumer.dashboards),
+            conv_dashboard_list([
                 {
                     "id": "file:tester",
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
-            ],
+            ]),
         )
         # assert restart is not called
         assert restart_patcher.call_count == 0
@@ -552,17 +577,17 @@ class TestDashboardConsumer(unittest.TestCase):
         self.setup_without_dropdowns(DASHBOARD_TEMPLATE)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
 
-        self.assertEqual(
-            self.harness.charm.grafana_consumer.dashboards,
-            [
-                {
-                    "id": "file:tester",
-                    "relation_id": "2",
-                    "charm": "grafana-k8s",
-                    "content": DASHBOARD_RENDERED_NO_DROPDOWNS,
-                }
-            ],
-        )
+
+        self.assertEqual(conv_dashboard_list(self.harness.charm.grafana_consumer.dashboards), conv_dashboard_list([{
+            "id": "file:tester",
+            "relation_id": "2",
+            "charm": "grafana-k8s",
+            "content": DASHBOARD_RENDERED_NO_DROPDOWNS,
+            "dashboard_uid": "deadbeef",
+            "dashboard_version": 0,
+            "dashboard_title": "",
+        }]))
+
         # assert restart is not called
         assert restart_patcher.call_count == 0
 
@@ -612,6 +637,9 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": VARIABLE_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -630,6 +658,9 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": ROW_ONLY_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -641,15 +672,18 @@ class TestDashboardConsumer(unittest.TestCase):
         self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
 
         self.assertEqual(
-            self.harness.charm.grafana_consumer.dashboards,
-            [
+            conv_dashboard_list(self.harness.charm.grafana_consumer.dashboards),
+            conv_dashboard_list([
                 {
                     "id": "file:tester",
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": INPUT_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
-            ],
+            ]),
         )
 
     def test_consumer_templates_with_null_datasource(self):
@@ -666,6 +700,9 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": NULL_DATASOURCE_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -684,6 +721,9 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": BUILTIN_DATASOURCE_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -703,6 +743,9 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DICT_DATASOURCE_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -721,6 +764,9 @@ class TestDashboardConsumer(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": EXISTING_VARIABLE_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )

--- a/tests/unit/test_dashboard_transform.py
+++ b/tests/unit/test_dashboard_transform.py
@@ -8,6 +8,7 @@ from typing import Dict, Optional
 import unittest
 import uuid
 from unittest.mock import patch
+from helpers import conv_dashboard_list
 
 from charms.grafana_k8s.v0.grafana_dashboard import (
     DATASOURCE_TEMPLATE_DROPDOWNS,
@@ -38,7 +39,8 @@ DASHBOARD_TEMPLATE = """
                 }
             ]
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -66,6 +68,7 @@ DASHBOARD_RENDERED = json.dumps(
                 ],
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -89,6 +92,7 @@ DASHBOARD_RENDERED_NO_TOPOLOGY = json.dumps(
                 ],
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -105,7 +109,8 @@ LOKI_DASHBOARD_TEMPLATE = r"""
                 }
             ]
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -133,6 +138,7 @@ LOKI_DASHBOARD_RENDERED = json.dumps(
                 ],
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -157,7 +163,8 @@ DASHBOARD_TEMPLATE_WITH_NEGATIVE = """
             ],
             "datasource": "${prometheusds}"
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -188,6 +195,7 @@ DASHBOARD_RENDERED_WITH_NEGATIVE = json.dumps(
                 "datasource": "${prometheusds}",
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -204,7 +212,8 @@ DASHBOARD_TEMPLATE_WITH_RANGES = """
             ],
             "datasource": "${prometheusds}"
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -232,6 +241,7 @@ DASHBOARD_RENDERED_WITH_RANGES = json.dumps(
                 "datasource": "${prometheusds}",
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -248,7 +258,8 @@ DASHBOARD_TEMPLATE_WITH_OFFSETS = """
             ],
             "datasource": "${prometheusds}"
         }
-    ]
+    ],
+    "uid": "deadbeef"
 }
 """
 
@@ -276,6 +287,7 @@ DASHBOARD_RENDERED_WITH_OFFSETS = json.dumps(
                 "datasource": "${prometheusds}",
             },
         ],
+        "uid": "deadbeef",
         "templating": {"list": list(TEMPLATE_DROPDOWNS)},
     }
 )
@@ -377,15 +389,18 @@ class TestDashboardLabelInjector(unittest.TestCase):
         self.assertEqual(self.harness.charm._stored.dashboard_events, 1)
 
         self.assertEqual(
-            self.harness.charm.grafana_consumer.dashboards,
-            [
+            conv_dashboard_list(self.harness.charm.grafana_consumer.dashboards),
+            conv_dashboard_list([
                 {
                     "id": "file:tester",
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
-            ],
+            ]),
         )
 
     @patch("platform.processor", lambda: "x86_64")
@@ -403,6 +418,9 @@ class TestDashboardLabelInjector(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED_NO_TOPOLOGY,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -422,6 +440,9 @@ class TestDashboardLabelInjector(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": LOKI_DASHBOARD_RENDERED,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -441,6 +462,9 @@ class TestDashboardLabelInjector(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED_WITH_NEGATIVE,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -460,6 +484,9 @@ class TestDashboardLabelInjector(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED_WITH_RANGES,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )
@@ -479,6 +506,9 @@ class TestDashboardLabelInjector(unittest.TestCase):
                     "relation_id": "2",
                     "charm": "grafana-k8s",
                     "content": DASHBOARD_RENDERED_WITH_OFFSETS,
+                    "dashboard_uid": "deadbeef",
+                    "dashboard_version": 0,
+                    "dashboard_title": "",
                 }
             ],
         )


### PR DESCRIPTION
This PR is a backport of  #484 to track/2.