### PR TITLE
fix: inclusive namecheck

### DIFF
--- a/lib/.wokeignore
+++ b/lib/.wokeignore
@@ -1,1 +1,2 @@
 charms/certificate_transfer_interface
+charms/grafana_k8s/v0/grafana_auth

--- a/tests/integration/grafana-tester/metadata.yaml
+++ b/tests/integration/grafana-tester/metadata.yaml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 name: grafana-tester
 description: |
-  This charm is nothing more than a dummy which can present itself to Grafana
+  This charm is nothing more than a tester which can present itself to Grafana
   to pass over dashboards and datasources which do nothing.
 summary: |
   A charm to test the Grafana operator

--- a/tests/integration/test_grafana_auth.py
+++ b/tests/integration/test_grafana_auth.py
@@ -2,7 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Tests the library using dummy requirer and provider charms.
+"""Tests the library using tester requirer and provider charms.
 
 It tests that the charms are able to relate and to exchange data.
 """


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes inclusive namecheck.
Failures here: https://github.com/canonical/grafana-k8s-operator/runs/70140470487

## Solution
<!-- A summary of the solution addressing the above issue -->
- Fixes namecheck issues in test files
- There are multiple failures in the `grafana_auth` lib because a constructor arg is called `whitelist`. Since changing that arg could break other users, I've added the whole file to the `.wokeignore` file under `lib`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
