### PR TITLE
feat(terraform): add channel validation

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,5 +38,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
-| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

See canonical/alertmanager-k8s-operator#403 for reference.