### PR TITLE
feat!: TF Lifecycle on resource changes

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -15,6 +15,7 @@ This is a Terraform module facilitating the deployment of grafana-k8s charm, usi
 | Name | Version |
 |------|---------|
 | <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -25,6 +26,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"grafana"` | no |
+| <a name="input_base"></a> [base](#input\_base) | The operating system on which to deploy. E.g. ubuntu@24.04. Changing this value for machine charms will trigger a replace by terraform. Check Charmhub for supported bases. | `string` | `"ubuntu@24.04"` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64"` | no |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,5 +13,5 @@ resource "juju_application" "grafana" {
     revision = data.juju_charm.grafana_info.revision
   }
 
-  lifecycle { replace_triggered_by = [terraform_data.grafana_resources] }
+  lifecycle { replace_triggered_by = [terraform_data.grafana_litestream_resource] }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ resource "juju_application" "grafana" {
   charm {
     name     = "grafana-k8s"
     channel  = var.channel
-    revision = var.revision
+    revision = data.juju_charm.grafana_info.revision
   }
 
   lifecycle { replace_triggered_by = [terraform_data.grafana_resources] }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,4 +12,6 @@ resource "juju_application" "grafana" {
     channel  = var.channel
     revision = var.revision
   }
+
+  lifecycle { replace_triggered_by = [terraform_data.grafana_resources] }
 }

--- a/terraform/upgrades.tf
+++ b/terraform/upgrades.tf
@@ -1,6 +1,8 @@
 # -------------- Upgrade logic --------------
 
 ## -------- Removed the litestream-image resource ----------
+# The litestream-image resource was removed and given a Juju bug, we need to add a lifecycle to
+# trigger integration replacement, otherwise the upgrade will fail
 # https://github.com/juju/juju/issues/21648
 # https://github.com/juju/juju/issues/22071
 resource "terraform_data" "grafana_resources" {

--- a/terraform/upgrades.tf
+++ b/terraform/upgrades.tf
@@ -1,0 +1,16 @@
+# -------------- Upgrade logic --------------
+
+## -------- grafana.revision >= 174 ----------
+# the ingress endpoint interface changes from traefik_route to ingress_per_app so we need a
+# lifecycle to trigger integration replacement, otherwise the upgrade will fail
+resource "terraform_data" "grafana_resources" {
+  input = data.juju_charm.grafana_info.resources
+}
+
+# -------------- # CharmHub API -------------- #
+
+data "juju_charm" "grafana_info" {
+  charm   = "grafana-k8s"
+  channel = var.channel
+  base    = var.base
+}

--- a/terraform/upgrades.tf
+++ b/terraform/upgrades.tf
@@ -6,7 +6,7 @@
 # https://github.com/juju/juju/issues/21648
 # https://github.com/juju/juju/issues/22071
 resource "terraform_data" "grafana_litestream_resource" {
-  input = contains(keys(data.juju_charm.grafana_info.resources), "litestream-image")
+  triggers_replace = contains(keys(data.juju_charm.grafana_info.resources), "litestream-image")
 }
 
 # -------------- # CharmHub API -------------- #

--- a/terraform/upgrades.tf
+++ b/terraform/upgrades.tf
@@ -1,8 +1,9 @@
 # -------------- Upgrade logic --------------
 
-## -------- grafana.revision >= 174 ----------
-# the ingress endpoint interface changes from traefik_route to ingress_per_app so we need a
-# lifecycle to trigger integration replacement, otherwise the upgrade will fail
+# TODO: Do we want to reference a commit hash instead of revision since the hash can link to all applicable revisions, but a revision can be on any track
+## -------- grafana.revision == 180 ----------
+# https://github.com/juju/juju/issues/21648
+# https://github.com/juju/juju/issues/22071
 resource "terraform_data" "grafana_resources" {
   input = data.juju_charm.grafana_info.resources
 }

--- a/terraform/upgrades.tf
+++ b/terraform/upgrades.tf
@@ -1,7 +1,6 @@
 # -------------- Upgrade logic --------------
 
-# TODO: Do we want to reference a commit hash instead of revision since the hash can link to all applicable revisions, but a revision can be on any track
-## -------- grafana.revision == 180 ----------
+## -------- Removed the litestream-image resource ----------
 # https://github.com/juju/juju/issues/21648
 # https://github.com/juju/juju/issues/22071
 resource "terraform_data" "grafana_resources" {

--- a/terraform/upgrades.tf
+++ b/terraform/upgrades.tf
@@ -5,8 +5,8 @@
 # trigger integration replacement, otherwise the upgrade will fail
 # https://github.com/juju/juju/issues/21648
 # https://github.com/juju/juju/issues/22071
-resource "terraform_data" "grafana_resources" {
-  input = data.juju_charm.grafana_info.resources
+resource "terraform_data" "grafana_litestream_resource" {
+  input = contains(keys(data.juju_charm.grafana_info.resources), "litestream-image")
 }
 
 # -------------- # CharmHub API -------------- #

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,14 +4,15 @@ variable "app_name" {
   default     = "grafana"
 }
 
+variable "base" {
+  description = "The operating system on which to deploy. E.g. ubuntu@24.04. Changing this value for machine charms will trigger a replace by terraform. Check Charmhub for supported bases."
+  default     = "ubuntu@24.04"
+  type        = string
+}
+
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
-
-  validation {
-    condition     = startswith(var.channel, "dev/")
-    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
-  }
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,11 @@ variable "base" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
A workaround for:
- https://github.com/juju/juju/issues/21648

Unblocking:
- https://github.com/canonical/observability-stack/pull/174

## Solution
<!-- A summary of the solution addressing the above issue -->
I checked the output of the juju_charm.resources for versions of Grafana in:
1. Track 2
```terraform
# Changes to Outputs:
#   + grafana_resources = {
#       + id               = (known after apply)
#       + input            = {
#           + grafana-image    = "77"
#           + litestream-image = "46"
#         }
#       + output           = (known after apply)
#       + triggers_replace = null
#     }
```
2. Track dev:
```terraform
# Changes to Outputs:
#   + grafana_resources = {
#       + id               = (known after apply)
#       + input            = {
#           + grafana-image = "78"
#         }
#       + output           = (known after apply)
#       + triggers_replace = null
#     }
```

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
We cannot scope the lifecycle to something specific like "a resource was removed, but not added" so we have to accept that this will always replace the Grafana application when the resources state for Grafana changes. The Juju bug this feature addresses does not happen when the plan notices the addition of a resource. Changes to the resources will only happen when:
1. we release new images -> rare
2. we remove an entire resource e.g., the database PR to Grafana removing litestream

Since Grafana is only a UI and not a datastore, this feature is likely fine and will not incur data loss.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
```terraform
terraform {
  required_version = ">= 1.5"
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "~> 1.0"
    }
  }
}

resource "juju_model" "grafana" {
  name = "grafana"
}

module "grafana" {
  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform?ref=track/2"
  channel            = "2/stable"
  model_uuid         = juju_model.grafana.uuid
}
```
```shell
❯ tf init
❯ tf apply
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
<img width="613" height="212" alt="image" src="https://github.com/user-attachments/assets/f8a5c66d-57a9-4c3f-91a1-06c32e241fad" />

then update the module and apply:
```terraform
module "grafana" {
  source             = "git::https://github.com/canonical/grafana-k8s-operator//terraform?ref=test/tf-lifecycle"
  channel            = "2/stable"
  model_uuid         = juju_model.grafana.uuid
}
```
```shell
❯ tf init -upgrade
❯ tf apply
Terraform will perform the following actions:

  # module.grafana.terraform_data.grafana_litestream_resource will be created
  + resource "terraform_data" "grafana_litestream_resource" {
      + id               = (known after apply)
      + triggers_replace = true
    }

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

then update the module & channel and apply:
```terraform
module "grafana" {
  source             = "../terraform"
  channel            = "dev/edge"
  model_uuid         = juju_model.grafana.uuid
}
```
```shell
❯ tf init -upgrade
❯ tf apply      
Terraform will perform the following actions:

  # module.grafana.juju_application.grafana will be replaced due to changes in replace_triggered_by
-/+ resource "juju_application" "grafana" {
      ~ id                 = "aec3ff6e-a3a0-44a7-8841-22fb83fd5500:grafana" -> (known after apply)
      ~ machines           = [] -> (known after apply)
      ~ model_type         = "caas" -> (known after apply)
        name               = "grafana"
      ~ storage            = [
          - {
              - count = 1 -> null
              - label = "database" -> null
              - pool  = "kubernetes" -> null
              - size  = "1G" -> null
            },
        ] -> (known after apply)
        # (6 unchanged attributes hidden)

      ~ charm {
          ~ base     = "ubuntu@24.04" -> (known after apply)
          ~ channel  = "2/stable" -> "dev/edge"
            name     = "grafana-k8s"
          ~ revision = 180 -> 186
        }
    }

  # module.grafana.terraform_data.grafana_litestream_resource must be replaced
-/+ resource "terraform_data" "grafana_litestream_resource" {
      ~ id               = "7678b3d7-6c22-b611-dc32-a5e766a625af" -> (known after apply)
      ~ triggers_replace = true -> false
    }

Plan: 2 to add, 0 to change, 2 to destroy.

Apply complete! Resources: 2 added, 0 changed, 2 destroyed.
```
<img width="763" height="219" alt="image" src="https://github.com/user-attachments/assets/e39a8454-f2ed-406f-b807-637f36b522fb" />


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
Since this will re-create the Grafana application, users will lose any custom configurations e.g., plugins that they have added to their Grafana. Once we backport `module.grafana.terraform_data.grafana_litestream_resource` to track/2, the user will have to run `terraform init -upgrade; terraform apply`, before they can safely migrate to track/dev or track/12.4.