### PR TITLE
feat: Add non-root user compliance

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,6 +4,7 @@
 type: charm
 name: grafana-k8s
 summary: Data visualization and observability with Grafana
+charm-user: non-root
 description: |
   Grafana K8s is a Juju charm that deploys and manages Grafana on Kubernetes. It provides a
   web interface for visualizing and exploring observability data and is a core component
@@ -41,6 +42,8 @@ assumes:
 containers:
   grafana:
     resource: grafana-image
+    uid: 584792
+    gid: 584792
     mounts:
       - storage: database
         location: /var/lib/grafana

--- a/image/rockcraft.yaml
+++ b/image/rockcraft.yaml
@@ -1,0 +1,112 @@
+name: grafana
+summary: Grafana in a ROCK.
+description: >
+  The open and composable observability and data visualization platform. Visualize metrics, logs, and traces from multiple sources like Prometheus, Loki, Elasticsearch, InfluxDB, Postgres and many more.
+
+version: "12.4.2"
+base: ubuntu@24.04
+license: AGPL-3.0
+
+run_user: _daemon_
+
+services:
+  grafana:
+    command: /bin/grafana-server --config /etc/grafana/grafana-config.ini
+    override: replace
+    startup: enabled
+
+platforms:
+  amd64:
+
+parts:
+  grafana:
+    plugin: go
+    source: https://github.com/grafana/grafana.git
+    source-tag: v12.4.2
+    source-depth: 1
+    build-snaps:
+      - go/1.24/stable
+    override-build: |
+      set -x
+      make build-go
+      find bin -type f -executable | while read f; do install -D -m 755 $f ${CRAFT_PART_INSTALL}/usr/$(echo $f | sed -e 's%linux-amd64/%%'); done
+      cp -rpv conf ${CRAFT_PART_INSTALL}/conf
+      mkdir -p ${CRAFT_PART_INSTALL}/etc/grafana
+      touch ${CRAFT_PART_INSTALL}/etc/grafana/grafana-config.ini
+    stage:
+      - bin/*
+      - usr/bin/grafana*
+      - conf/
+      - etc/grafana
+
+  grafana-ui:
+    after: [grafana]
+    plugin: nil
+    source-type: git
+    source: https://github.com/grafana/grafana.git
+    source-tag: v12.4.2
+    build-snaps:
+      - node/22/stable
+    build-environment:
+      - NODE_OPTIONS: "--max-old-space-size=4096"
+    override-build: |
+      # REF: https://github.com/grafana/grafana/blob/v12.4.2/contribute/developer-guide.md
+      npm install -g corepack@latest
+      corepack enable
+      corepack install
+      [[ -v http_proxy ]] && yarn config set httpProxy ${http_proxy}
+      [[ -v https_proxy ]] && yarn config set httpsProxy ${https_proxy}
+      #yarn install --immutable
+
+      # Instead of the line above, we do the block below
+      # There is a known issue with Yarn 4.0.0-rc.1 where it gets an einval error when trying to fetch a pinned git commit: https://github.com/yarnpkg/berry/issues/3500
+      COMMIT="a10c748f40edc538425b458af4e471a8262ec4ed"
+      TARBALL_URL="https://github.com/grafana/react-data-grid/archive/${COMMIT}.tar.gz"
+      find . -name package.json -not -path '*/node_modules/*' \
+        -exec sed -i "s|grafana/react-data-grid#${COMMIT}|${TARBALL_URL}|g" {} +
+      yarn install
+
+      # Normal flow
+      make build-js
+      mkdir -p ${CRAFT_PART_INSTALL}/{public,tools}
+      cp -rpv public/* ${CRAFT_PART_INSTALL}/public/
+    stage:
+      - public/
+      - tools/
+
+  ca-certs:
+    plugin: nil
+    overlay-packages:
+      - ca-certificates
+
+  user-setup:
+    plugin: nil
+    after:
+      - grafana
+      - grafana-ui
+      - ca-certs
+    override-prime: |
+      # Please refer to https://discourse.ubuntu.com/t/unifying-user-identity-across-snaps-and-rocks/36469
+      # for more information about shared user.
+      HUB_GID=584792
+      HUB_UID=584792
+
+      craftctl default
+
+      chown -R ${HUB_GID}:${HUB_UID} etc/grafana/
+      chmod -R 750 etc/grafana/
+
+      chown -R ${HUB_GID}:${HUB_UID} usr/local/share/ca-certificates/
+      chmod -R 750 usr/local/share/ca-certificates/
+
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - grafana
+      - grafana-ui
+      - ca-certs
+      - user-setup
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -441,8 +441,11 @@ def assert_security_context(
     Raises:
         AssertionError: If any security context attribute doesn't match.
     """
-    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    pod = lightkube_client.get(Pod, pod_name, namespace=model_name)
+    assert pod.spec is not None, f"Pod {pod_name} has no spec"
+    containers: list = pod.spec.containers
     container = next((c for c in containers if c.name == container_name), None)
+    assert container is not None, f"Container {container_name} not found in pod {pod_name}"
     security_context = container.securityContext
     for key, value in container_securitycontext_map.get(container_name, {}).items():
         assert getattr(security_context, key) == value, (

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,11 +3,14 @@
 # See LICENSE file for licensing details.
 import json
 import logging
+import subprocess
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
+import lightkube
 import requests
 import yaml
+from lightkube.resources.core_v1 import Pod
 from asyncstdlib import functools
 from pytest_operator.plugin import OpsTest
 from urllib.parse import urlparse
@@ -347,6 +350,105 @@ def get_traces(tempo_host: str, service_name="tracegen-otlp_http", tls=True):
     assert req.status_code == 200
     traces = json.loads(req.text)["traces"]
     return traces
+
+
+# -- Security context helpers for non-root compliance verification --
+
+class ContainerSecurityContext:
+    """TypedDict representing Kubernetes container security context settings."""
+
+    runAsUser: int | None  # noqa N815
+    runAsGroup: int | None  # noqa N815
+    runAsNonRoot: bool | None  # noqa N815
+
+
+def generate_container_securitycontext_map(
+    metadata_yaml: dict, juju_user_id: int = 170
+) -> dict[str, dict]:
+    """Generate a mapping of container names to their security context UID/GID settings.
+
+    This function extracts container security context information from a charm's metadata
+    and creates a mapping that includes both application containers and the charm container.
+
+    Args:
+        metadata_yaml: The charm's metadata dictionary, expected to contain a
+            "containers" key with container definitions including "uid" and "gid" fields.
+        juju_user_id: The user ID and group ID to use for the charm container.
+            Defaults to 170, which is the standard Juju user ID.
+
+    Returns:
+        A mapping of container names to security context dictionaries.
+    """
+    c_uid_map = {}
+    for k, v in metadata_yaml.get("containers", {}).items():
+        c_uid_map[k] = {
+            "runAsUser": v["uid"],
+            "runAsGroup": v["gid"],
+        }
+    c_uid_map["charm"] = {"runAsUser": juju_user_id, "runAsGroup": juju_user_id}
+    return c_uid_map
+
+
+def get_pod_names(model: str, application_name: str) -> list[str]:
+    """Retrieve names of all pods belonging to a specific Juju application.
+
+    This function uses kubectl to query the Kubernetes cluster for pods that match
+    the given application name within the specified Juju model namespace.
+
+    Args:
+        model: The name of the Juju model, which corresponds to the Kubernetes
+            namespace where the pods are deployed.
+        application_name: The name of the Juju application whose pods should
+            be retrieved.
+
+    Returns:
+        A list of pod names matching the application.
+    """
+    cmd = [
+        "kubectl",
+        "get",
+        "pods",
+        f"-n{model}",
+        f"-lapp.kubernetes.io/name={application_name}",
+        "--no-headers",
+        "-o=custom-columns=NAME:.metadata.name",
+    ]
+    proc = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+    )
+    stdout = proc.stdout.decode("utf8")
+    return stdout.split()
+
+
+def assert_security_context(
+    lightkube_client: lightkube.Client,
+    pod_name: str,
+    container_name: str,
+    container_securitycontext_map: Dict[str, dict],
+    model_name: str,
+) -> None:
+    """Assert that a container's security context matches expected UID/GID settings.
+
+    Args:
+        lightkube_client: A configured lightkube client instance.
+        pod_name: The name of the pod containing the container to check.
+        container_name: The name of the specific container within the pod.
+        container_securitycontext_map: A mapping of container names to their expected
+            security context settings.
+        model_name: The name of the Juju model (Kubernetes namespace).
+
+    Raises:
+        AssertionError: If any security context attribute doesn't match.
+    """
+    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    container = next((c for c in containers if c.name == container_name), None)
+    security_context = container.securityContext
+    for key, value in container_securitycontext_map.get(container_name, {}).items():
+        assert getattr(security_context, key) == value, (
+            f"Container {container_name}: expected {key}={value}, "
+            f"got {getattr(security_context, key)}"
+        )
 
 
 @retry(stop=stop_after_attempt(15), wait=wait_exponential(multiplier=1, min=4, max=10))

--- a/tests/integration/test_get_password.py
+++ b/tests/integration/test_get_password.py
@@ -7,13 +7,20 @@ from pathlib import Path
 import sh
 import pytest
 import yaml
-from helpers import oci_image
+import lightkube
+from helpers import (
+    assert_security_context,
+    generate_container_securitycontext_map,
+    get_pod_names,
+    oci_image,
+)
 
 # pyright: reportAttributeAccessIssue=false
 
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+CONTAINERS_SECURITY_CONTEXT_MAP = generate_container_securitycontext_map(METADATA)
 app_name = "grafana"
 grafana_resources = {
     "grafana-image": oci_image("./charmcraft.yaml", "grafana-image"),
@@ -62,3 +69,24 @@ async def test_password_returns_correct_value_after_upgrading(ops_test, grafana_
     action = await ops_test.model.applications[app_name].units[0].run_action("get-admin-password")
     msg = (await action.wait()).results["admin-password"]
     assert pw == msg
+
+
+@pytest.mark.parametrize("container_name", list(CONTAINERS_SECURITY_CONTEXT_MAP.keys()))
+def test_container_security_context(
+    ops_test,
+    container_name: str,
+) -> None:
+    """Test container security context is correctly set.
+
+    Verify that container spec defines the security context with correct
+    user ID and group ID.
+    """
+    lightkube_client = lightkube.Client()
+    pod_name = get_pod_names(ops_test.model_name, app_name)[0]
+    assert_security_context(
+        lightkube_client,
+        pod_name,
+        container_name,
+        CONTAINERS_SECURITY_CONTEXT_MAP,
+        ops_test.model_name,
+    )


### PR DESCRIPTION
## Assessment

- **Charm name**: grafana-k8s
- **Non-root charm container**: NON-COMPLIANT — `charm-user` key was missing
- **Workloads**:
  - **grafana**: NON-COMPLIANT — no `uid`/`gid` set; image runs as root (uid=0)

## Mitigation

1. Added `charm-user: non-root` to `charmcraft.yaml`
2. Added `uid: 584792` and `gid: 584792` to the grafana container in `charmcraft.yaml`
3. Created `image/rockcraft.yaml` with:
   - `run_user: _daemon_` to ensure the image runs as a non-root user
   - A `user-setup` part that sets proper permissions (750) on `/etc/grafana/` and `/usr/local/share/ca-certificates/` for UID/GID 584792

## Verification

- Added security context assertion helpers (`generate_container_securitycontext_map`, `get_pod_names`, `assert_security_context`) to `tests/integration/helpers.py`
- Added `test_container_security_context` to `tests/integration/test_get_password.py` that verifies container security contexts match expected UID/GID values from `charmcraft.yaml`