### PR TITLE
feat: add non-root user compliance

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -38,9 +38,13 @@ assumes:
   - k8s-api
   - juju >= 3.6
 
+charm-user: non-root
+
 containers:
   grafana:
     resource: grafana-image
+    uid: 584792
+    gid: 584792
     mounts:
       - storage: database
         location: /var/lib/grafana
@@ -154,7 +158,7 @@ resources:
   grafana-image:
     type: oci-image
     description: upstream docker image for Grafana
-    upstream-source: docker.io/ubuntu/grafana@sha256:41a05082db41bebd4997021e4888d33ba5dd516d33a4fc2087d24c022bb4ebd5  # SP: oci-image tag: 12.4-24.04
+    upstream-source: docker.io/edeusebio85/grafana:12.4.2-non-root
 
 platforms:
   ubuntu@24.04:amd64:

--- a/image/rockcraft.yaml
+++ b/image/rockcraft.yaml
@@ -1,0 +1,118 @@
+name: grafana
+summary: Grafana in a ROCK.
+description: >
+  The open and composable observability and data visualization platform. Visualize metrics, logs, and traces from multiple sources like Prometheus, Loki, Elasticsearch, InfluxDB, Postgres and many more.
+
+version: "12.4.2"
+base: ubuntu@24.04
+license: AGPL-3.0
+
+run_user: _daemon_
+
+services:
+  grafana:
+    command: /bin/grafana-server --config /etc/grafana/grafana-config.ini
+    override: replace
+    startup: enabled
+
+platforms:
+  amd64:
+
+parts:
+  grafana:
+    plugin: go
+    source: https://github.com/grafana/grafana.git
+    source-tag: v12.4.2
+    source-depth: 1
+    build-snaps:
+      - go/1.24/stable
+    override-build: |
+      set -x
+      make build-go
+      find bin -type f -executable | while read f; do install -D -m 755 $f ${CRAFT_PART_INSTALL}/usr/$(echo $f | sed -e 's%linux-amd64/%%'); done
+      cp -rpv conf ${CRAFT_PART_INSTALL}/conf
+      mkdir -p ${CRAFT_PART_INSTALL}/etc/grafana
+      touch ${CRAFT_PART_INSTALL}/etc/grafana/grafana-config.ini
+    stage:
+      - bin/*
+      - usr/bin/grafana*
+      - conf/
+      - etc/grafana
+
+  grafana-ui:
+    after: [grafana]
+    plugin: nil
+    source-type: git
+    source: https://github.com/grafana/grafana.git
+    source-tag: v12.4.2
+    build-snaps:
+      - node/22/stable
+    build-environment:
+      - NODE_OPTIONS: "--max-old-space-size=4096"
+    override-build: |
+      # REF: https://github.com/grafana/grafana/blob/v12.4.2/contribute/developer-guide.md
+      npm install -g corepack@latest
+      corepack enable
+      corepack install
+      [[ -v http_proxy ]] && yarn config set httpProxy ${http_proxy}
+      [[ -v https_proxy ]] && yarn config set httpsProxy ${https_proxy}
+      #yarn install --immutable
+
+      # Instead of the line above, we do the block below
+      # There is a known issue with Yarn 4.0.0-rc.1 where it gets an einval error when trying to fetch a pinned git commit: https://github.com/yarnpkg/berry/issues/3500
+      COMMIT="a10c748f40edc538425b458af4e471a8262ec4ed"
+      TARBALL_URL="https://github.com/grafana/react-data-grid/archive/${COMMIT}.tar.gz"
+      find . -name package.json -not -path '*/node_modules/*' \
+        -exec sed -i "s|grafana/react-data-grid#${COMMIT}|${TARBALL_URL}|g" {} +
+      yarn install
+
+      # Normal flow
+      make build-js
+      mkdir -p ${CRAFT_PART_INSTALL}/{public,tools}
+      cp -rpv public/* ${CRAFT_PART_INSTALL}/public/
+    stage:
+      - public/
+      - tools/
+
+  ca-certs:
+    plugin: nil
+    overlay-packages:
+      - ca-certificates
+
+  user-setup:
+    plugin: nil
+    after:
+      - grafana
+      - grafana-ui
+      - ca-certs
+    override-prime: |
+      # Please refer to https://discourse.ubuntu.com/t/unifying-user-identity-across-snaps-and-rocks/36469
+      # for more information about shared user.
+      HUB_GID=584792
+      HUB_UID=584792
+
+      craftctl default
+
+      chown -R ${HUB_GID}:${HUB_UID} etc/grafana/
+      chmod -R 750 etc/grafana/
+
+      chown -R ${HUB_GID}:${HUB_UID} usr/local/share/ca-certificates/ 2>/dev/null || true
+      chmod -R 750 usr/local/share/ca-certificates/ 2>/dev/null || true
+
+      chown -R ${HUB_GID}:${HUB_UID} usr/local/bin/ 2>/dev/null || true
+      chmod -R 755 usr/local/bin/ 2>/dev/null || true
+
+      chown -R ${HUB_GID}:${HUB_UID} var/lib/grafana/ 2>/dev/null || true
+      chmod -R 750 var/lib/grafana/ 2>/dev/null || true
+
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - grafana
+      - grafana-ui
+      - ca-certs
+      - user-setup
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,12 +3,15 @@
 # See LICENSE file for licensing details.
 import json
 import logging
+import subprocess
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple, TypedDict
 
+import lightkube
 import requests
 import yaml
 from asyncstdlib import functools
+from lightkube.resources.core_v1 import Pod
 from pytest_operator.plugin import OpsTest
 from urllib.parse import urlparse
 from workload import Grafana
@@ -412,15 +415,6 @@ class ModelConfigChange:
         await self.ops_test.model.set_config(self.revert_to)
 
 
-# Security context verification helpers for non-root compliance testing
-
-import subprocess
-from typing import Dict, TypedDict
-
-import lightkube
-from lightkube.resources.core_v1 import Pod
-
-
 class ContainerSecurityContext(TypedDict):
     """TypedDict representing Kubernetes container security context settings."""
 
@@ -438,8 +432,13 @@ def generate_container_securitycontext_map(
         c_uid_map[k] = ContainerSecurityContext(
             runAsUser=v["uid"],
             runAsGroup=v["gid"],
+            runAsNonRoot=True,
         )
-    c_uid_map["charm"] = {"runAsUser": juju_user_id, "runAsGroup": juju_user_id}
+    c_uid_map["charm"] = ContainerSecurityContext(
+        runAsUser=juju_user_id,
+        runAsGroup=juju_user_id,
+        runAsNonRoot=None,
+    )
     return c_uid_map
 
 
@@ -467,8 +466,11 @@ def assert_security_context(
     model_name: str,
 ) -> None:
     """Assert that a container's security context matches expected UID/GID settings."""
-    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers  # type: ignore
     container = next((c for c in containers if c.name == container_name), None)
+    assert container is not None, f"Container '{container_name}' not found in pod '{pod_name}'"
     security_context = container.securityContext
-    for key, value in container_securitycontext_map.get(container_name).items():
+    expected_context = container_securitycontext_map.get(container_name)
+    assert expected_context is not None, f"No expected security context for container '{container_name}'"
+    for key, value in expected_context.items():
         assert getattr(security_context, key) == value

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -410,3 +410,65 @@ class ModelConfigChange:
         """On exit, the modified config options are reverted to their original values."""
         assert self.ops_test.model
         await self.ops_test.model.set_config(self.revert_to)
+
+
+# Security context verification helpers for non-root compliance testing
+
+import subprocess
+from typing import Dict, TypedDict
+
+import lightkube
+from lightkube.resources.core_v1 import Pod
+
+
+class ContainerSecurityContext(TypedDict):
+    """TypedDict representing Kubernetes container security context settings."""
+
+    runAsUser: int | None  # noqa N815
+    runAsGroup: int | None  # noqa N815
+    runAsNonRoot: bool | None  # noqa N815
+
+
+def generate_container_securitycontext_map(
+    metadata_yaml: dict, juju_user_id: int = 170
+) -> dict[str, ContainerSecurityContext]:
+    """Generate a mapping of container names to their security context UID/GID settings."""
+    c_uid_map = {}
+    for k, v in metadata_yaml.get("containers", {}).items():
+        c_uid_map[k] = ContainerSecurityContext(
+            runAsUser=v["uid"],
+            runAsGroup=v["gid"],
+        )
+    c_uid_map["charm"] = {"runAsUser": juju_user_id, "runAsGroup": juju_user_id}
+    return c_uid_map
+
+
+def get_pod_names(model: str, application_name: str) -> list[str]:
+    """Retrieve names of all pods belonging to a specific Juju application."""
+    cmd = [
+        "kubectl",
+        "get",
+        "pods",
+        f"-n{model}",
+        f"-lapp.kubernetes.io/name={application_name}",
+        "--no-headers",
+        "-o=custom-columns=NAME:.metadata.name",
+    ]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE)
+    stdout = proc.stdout.decode("utf8")
+    return stdout.split()
+
+
+def assert_security_context(
+    lightkube_client: lightkube.Client,
+    pod_name: str,
+    container_name: str,
+    container_securitycontext_map: Dict[str, ContainerSecurityContext],
+    model_name: str,
+) -> None:
+    """Assert that a container's security context matches expected UID/GID settings."""
+    containers: list = lightkube_client.get(Pod, pod_name, namespace=model_name).spec.containers
+    container = next((c for c in containers if c.name == container_name), None)
+    security_context = container.securityContext
+    for key, value in container_securitycontext_map.get(container_name).items():
+        assert getattr(security_context, key) == value

--- a/tests/integration/test_security_context.py
+++ b/tests/integration/test_security_context.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for non-root container security context compliance."""
+
+import logging
+from pathlib import Path
+
+import lightkube
+import pytest
+import yaml
+from helpers import (
+    assert_security_context,
+    generate_container_securitycontext_map,
+    get_pod_names,
+    oci_image,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+CONTAINERS_SECURITY_CONTEXT_MAP = generate_container_securitycontext_map(METADATA)
+
+grafana_resources = {
+    "grafana-image": oci_image("./charmcraft.yaml", "grafana-image"),
+}
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, grafana_charm):
+    """Deploy the grafana charm and wait for active status."""
+    await ops_test.model.deploy(
+        grafana_charm,
+        resources=grafana_resources,
+        application_name="grafana",
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=["grafana"],
+        status="active",
+        timeout=600,
+    )
+
+
+@pytest.mark.parametrize("container_name", list(CONTAINERS_SECURITY_CONTEXT_MAP.keys()))
+async def test_container_security_context(
+    ops_test: OpsTest,
+    container_name: str,
+) -> None:
+    """Test container security context is correctly set.
+
+    Verify that container spec defines the security context with correct
+    user ID and group ID.
+    """
+    lightkube_client = lightkube.Client()
+    pod_name = get_pod_names(ops_test.model_name, "grafana")[0]
+    assert_security_context(
+        lightkube_client,
+        pod_name,
+        container_name,
+        CONTAINERS_SECURITY_CONTEXT_MAP,
+        ops_test.model_name,
+    )

--- a/tests/integration/test_security_context.py
+++ b/tests/integration/test_security_context.py
@@ -31,6 +31,7 @@ grafana_resources = {
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, grafana_charm):
     """Deploy the grafana charm and wait for active status."""
+    assert ops_test.model, "ops_test.model is not initialized"
     await ops_test.model.deploy(
         grafana_charm,
         resources=grafana_resources,
@@ -54,6 +55,7 @@ async def test_container_security_context(
     Verify that container spec defines the security context with correct
     user ID and group ID.
     """
+    assert ops_test.model_name, "model_name is not set"
     lightkube_client = lightkube.Client()
     pod_name = get_pod_names(ops_test.model_name, "grafana")[0]
     assert_security_context(


### PR DESCRIPTION
## Assessment

The `grafana-k8s-operator` charm was assessed for non-root user compliance:

| Check | Status |
|-------|--------|
| Non-root charm container (`charm-user: non-root`) | ❌ Non-compliant |
| Workload container `grafana` (`uid`/`gid: 584792`) | ❌ Non-compliant |
| Image permissions for non-root user | ❌ Non-compliant (runs as root) |

## Mitigation

1. **charmcraft.yaml**: Added `charm-user: non-root` and `uid`/`gid: 584792` for the `grafana` container
2. **rockcraft.yaml**: Created based on `canonical/grafana-rock` with:
   - `run_user: _daemon_` for non-root execution
   - `user-setup` part setting correct ownership (`584792:584792`) and permissions on `/etc/grafana/`, `/usr/local/share/ca-certificates/`
3. **Image**: Built and published to `docker.io/edeusebio85/grafana:12.4.2-non-root`
4. **charmcraft.yaml**: Updated `upstream-source` to reference the new non-root image

## Verification

- Added `assert_security_context`, `generate_container_securitycontext_map`, and `get_pod_names` helpers to `tests/integration/helpers.py`
- Added `test_security_context.py` integration test that verifies container security contexts match the expected UID/GID values from `charmcraft.yaml`