### PR TITLE
ci: add explicit workflow permissions for CodeQL

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,6 +2,13 @@ name: Pull Requests
 
 on: pull_request
 
+permissions:
+  # Required for all workflows
+  security-events: write
+  # Only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   pull-request:
     name: PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for all workflows
+  security-events: write
+  # Only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v2


### PR DESCRIPTION
Add explicit permissions block to workflows calling central CI from canonical/observability.

Required due to org-level GitHub Actions permission changes (default changed from read-write to read). The CodeQL analysis in the reusable workflow requires security-events: write permission.