### PR TITLE
fix: Make unit-unavailable alert less noisy

### DIFF
--- a/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/src/prometheus_alert_rules/unit_unavailable.rule
@@ -3,9 +3,9 @@ groups:
     rules:
     - alert: GrafanaUnitIsUnavailable
       expr: up{} < 1
-      for: 0m
+      for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         summary: Grafana unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} unavailable
         description: >
@@ -14,9 +14,9 @@ groups:
 
     - alert: GrafanaUnitIsDown
       expr: avg_over_time(up{}[1m]) < 0.5
-      for: 0m
+      for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         summary: Grafana unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} has been unreachable at least 50% of the time over the last minute
         description: >


### PR DESCRIPTION
## Issue
Solves #513 


## Solution
two-fold:
1. alert now warning, instead of critical
2. Needs to be unavailable for more than 5m


## Context
The alerts by the grafana charm are too noisy and tend to flap a bit.


## Testing Instructions
None


## Upgrade Notes
None
