### PR TITLE
fix: `grafana_dashboard` flaplint issues

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -184,7 +184,7 @@ import platform
 import re
 import subprocess
 import tempfile
-import uuid
+
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import yaml
@@ -1373,7 +1373,7 @@ class GrafanaDashboardProvider(Object):
             "templates": new_templates,
             "uuid": hashlib.shake_128(
                 json.dumps(new_templates, sort_keys=True).encode()
-            ).digest(16).hex(),
+            ).digest(8).hex(),
         }
 
         relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
@@ -1875,7 +1875,7 @@ class GrafanaDashboardAggregator(Object):
                     "templates": new_templates,
                     "uuid": hashlib.shake_128(
                         json.dumps(new_templates, sort_keys=True).encode()
-                    ).digest(16).hex(),
+                    ).digest(8).hex(),
                 }
                 grafana_relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
 
@@ -1896,7 +1896,7 @@ class GrafanaDashboardAggregator(Object):
             "templates": remaining_templates,
             "uuid": hashlib.shake_128(
                 json.dumps(remaining_templates, sort_keys=True).encode()
-            ).digest(16).hex(),
+            ).digest(8).hex(),
         }
 
         if self._charm.unit.is_leader():
@@ -2141,8 +2141,8 @@ class CosTool:
             #       - alert: OtherAlert
             #         expr: up
             transformed_rules = {"groups": []}  # type: ignore
-            for rule in rules["groups"]:
-                transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
+            for i, rule in enumerate(rules["groups"]):
+                transformed = {"name": f"group_{i}", "rules": [rule]}
                 transformed_rules["groups"].append(transformed)
 
             rule_path.write_text(yaml.safe_dump(transformed_rules, sort_keys=True)) # databag-order: ignore

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -392,6 +392,13 @@ REACTIVE_CONVERTER = {  # type: ignore
 }
 
 
+def _data_hash(data: Any) -> str:
+    """Deterministic hash of a template dict for use as a stable relation data key."""
+    return hashlib.shake_128(
+        json.dumps(data, sort_keys=True).encode()
+    ).digest(8).hex()
+
+
 class RelationNotFoundError(Exception):
     """Raised if there is no relation with the given name."""
 
@@ -1371,9 +1378,7 @@ class GrafanaDashboardProvider(Object):
         # templates haven't changed, avoiding spurious relation-changed events.
         stored_data = {
             "templates": new_templates,
-            "uuid": hashlib.shake_128(
-                json.dumps(new_templates, sort_keys=True).encode()
-            ).digest(8).hex(),
+            "uuid": _data_hash(new_templates),
         }
 
         relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
@@ -1873,9 +1878,7 @@ class GrafanaDashboardAggregator(Object):
                 # templates haven't changed, avoiding spurious relation-changed events.
                 stored_data = {
                     "templates": new_templates,
-                    "uuid": hashlib.shake_128(
-                        json.dumps(new_templates, sort_keys=True).encode()
-                    ).digest(8).hex(),
+                    "uuid": _data_hash(new_templates),
                 }
                 grafana_relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
 
@@ -1894,9 +1897,7 @@ class GrafanaDashboardAggregator(Object):
         remaining_templates = type_convert_stored(self._stored.dashboard_templates)  # pyright: ignore
         stored_data = {
             "templates": remaining_templates,
-            "uuid": hashlib.shake_128(
-                json.dumps(remaining_templates, sort_keys=True).encode()
-            ).digest(8).hex(),
+            "uuid": _data_hash(remaining_templates),
         }
 
         if self._charm.unit.is_leader():

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -217,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 50
+LIBPATCH = 51
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -1371,9 +1371,9 @@ class GrafanaDashboardProvider(Object):
         # templates haven't changed, avoiding spurious relation-changed events.
         stored_data = {
             "templates": new_templates,
-            "uuid": hashlib.sha256(
+            "uuid": hashlib.shake_128(
                 json.dumps(new_templates, sort_keys=True).encode()
-            ).hexdigest()[:16],
+            ).digest(16).hex(),
         }
 
         relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
@@ -1873,9 +1873,9 @@ class GrafanaDashboardAggregator(Object):
                 # templates haven't changed, avoiding spurious relation-changed events.
                 stored_data = {
                     "templates": new_templates,
-                    "uuid": hashlib.sha256(
+                    "uuid": hashlib.shake_128(
                         json.dumps(new_templates, sort_keys=True).encode()
-                    ).hexdigest()[:16],
+                    ).digest(16).hex(),
                 }
                 grafana_relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
 
@@ -1894,9 +1894,9 @@ class GrafanaDashboardAggregator(Object):
         remaining_templates = type_convert_stored(self._stored.dashboard_templates)  # pyright: ignore
         stored_data = {
             "templates": remaining_templates,
-            "uuid": hashlib.sha256(
+            "uuid": hashlib.shake_128(
                 json.dumps(remaining_templates, sort_keys=True).encode()
-            ).hexdigest()[:16],
+            ).digest(16).hex(),
         }
 
         if self._charm.unit.is_leader():
@@ -2145,7 +2145,7 @@ class CosTool:
                 transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
                 transformed_rules["groups"].append(transformed)
 
-            rule_path.write_text(yaml.dump(transformed_rules))  # databag-order: ignore
+            rule_path.write_text(yaml.safe_dump(transformed_rules, sort_keys=True)) # databag-order: ignore
 
             args = [str(self.path), "validate", str(rule_path)]
             # noinspection PyBroadException

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1366,10 +1366,14 @@ class GrafanaDashboardProvider(Object):
             return  # No change in templates, don't update the databag
 
         # It's completely ridiculous to add a UUID, but if we don't have some
-        # pseudo-random value, this never makes it across 'juju set-state'
+        # pseudo-random value, this never makes it across 'juju set-state'.
+        # Use a deterministic hash of the templates so the value is stable when
+        # templates haven't changed, avoiding spurious relation-changed events.
         stored_data = {
             "templates": new_templates,
-            "uuid": str(uuid.uuid4()),
+            "uuid": hashlib.sha256(
+                json.dumps(new_templates, sort_keys=True).encode()
+            ).hexdigest()[:16],
         }
 
         relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
@@ -1733,7 +1737,7 @@ class GrafanaDashboardConsumer(Object):
         if not peers or not peers.data:
             logger.info("set_peer_data: no peer relation. Is the charm being installed/removed?")
             return
-        peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore[attr-defined]
+        peers.data[self._charm.app][key] = json.dumps(data, sort_keys=True)  # type: ignore[attr-defined]
 
     def get_peer_data(self, key: str) -> Any:
         """Retrieve information from the peer data bucket instead of `StoredState`."""
@@ -1864,10 +1868,14 @@ class GrafanaDashboardAggregator(Object):
                 if new_templates == existing_templates:
                     continue  # No change in templates, don't update the databag
 
-                # It's still ridiculous to add a UUID here, but needed
+                # It's still ridiculous to add a UUID here, but needed.
+                # Use a deterministic hash of the templates so the value is stable when
+                # templates haven't changed, avoiding spurious relation-changed events.
                 stored_data = {
                     "templates": new_templates,
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": hashlib.sha256(
+                        json.dumps(new_templates, sort_keys=True).encode()
+                    ).hexdigest()[:16],
                 }
                 grafana_relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
 
@@ -1883,9 +1891,12 @@ class GrafanaDashboardAggregator(Object):
         for id in app_ids:
             del self._stored.dashboard_templates[id]  # type: ignore
 
+        remaining_templates = type_convert_stored(self._stored.dashboard_templates)  # pyright: ignore
         stored_data = {
-            "templates": type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
-            "uuid": str(uuid.uuid4()),
+            "templates": remaining_templates,
+            "uuid": hashlib.sha256(
+                json.dumps(remaining_templates, sort_keys=True).encode()
+            ).hexdigest()[:16],
         }
 
         if self._charm.unit.is_leader():
@@ -2134,7 +2145,7 @@ class CosTool:
                 transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
                 transformed_rules["groups"].append(transformed)
 
-            rule_path.write_text(yaml.dump(transformed_rules))
+            rule_path.write_text(yaml.dump(transformed_rules))  # databag-order: ignore
 
             args = [str(self.path), "validate", str(rule_path)]
             # noinspection PyBroadException

--- a/tests/unit/test_dashboard_provider.py
+++ b/tests/unit/test_dashboard_provider.py
@@ -128,7 +128,7 @@ class TestDashboardProvider(unittest.TestCase):
         self.assertDictEqual(
             {
                 "templates": RELATION_TEMPLATES_DATA,
-                "uuid": "10aa88d3d745c3c1",
+                "uuid": "ab8a472458fce843",
             },
             data,
         )
@@ -144,7 +144,7 @@ class TestDashboardProvider(unittest.TestCase):
 
         expected_data_builtin_dashboards = {
             "templates": copy.deepcopy(RELATION_TEMPLATES_DATA),
-            "uuid": "10aa88d3d745c3c1",
+            "uuid": "ab8a472458fce843",
         }
 
         expected_data = copy.deepcopy(expected_data_builtin_dashboards)
@@ -161,7 +161,7 @@ class TestDashboardProvider(unittest.TestCase):
                 "unit": "provider-tester/0",
             },
         }
-        expected_data["uuid"] = "61a7f8340b79b2d7"
+        expected_data["uuid"] = "2eb3bce253da6ffc"
 
         self.assertDictEqual(expected_data, actual_data)
         self.harness.charm.provider.remove_non_builtin_dashboards()
@@ -181,7 +181,7 @@ class TestDashboardProvider(unittest.TestCase):
 
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "10aa88d3d745c3c1",
+            "uuid": "ab8a472458fce843",
         }
 
         self.assertDictEqual(expected_data, actual_data)
@@ -202,7 +202,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "10aa88d3d745c3c1",
+            "uuid": "ab8a472458fce843",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -213,7 +213,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": MANUAL_TEMPLATE_DATA,
-            "uuid": "62d5ee2efbab0247",
+            "uuid": "84a6e9197c918137",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -225,7 +225,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "10aa88d3d745c3c1",
+            "uuid": "ab8a472458fce843",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -236,7 +236,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": MANUAL_TEMPLATE_DATA_NO_DROPDOWNS,
-            "uuid": "f8b869f1372f91d6",
+            "uuid": "32fb32d1aaa96c16",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -248,7 +248,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "10aa88d3d745c3c1",
+            "uuid": "ab8a472458fce843",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -259,7 +259,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         empty_data = {
             "templates": {},
-            "uuid": "44136fa355b3678a",
+            "uuid": "468067f3e2f88531",
         }
         self.assertDictEqual(empty_data, actual_data)
 
@@ -271,7 +271,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "10aa88d3d745c3c1",
+            "uuid": "ab8a472458fce843",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -282,6 +282,6 @@ class TestDashboardProvider(unittest.TestCase):
         )
         empty_data = {
             "templates": {},
-            "uuid": "44136fa355b3678a",
+            "uuid": "468067f3e2f88531",
         }
         self.assertDictEqual(empty_data, actual_data)

--- a/tests/unit/test_dashboard_provider.py
+++ b/tests/unit/test_dashboard_provider.py
@@ -4,7 +4,6 @@
 import copy
 import json
 import unittest
-import uuid
 from unittest.mock import patch
 
 from charms.grafana_k8s.v0.grafana_dashboard import (
@@ -105,7 +104,6 @@ class ProviderCharm(CharmBase):
             self._stored.invalid_events += 1
 
 
-@patch.object(uuid, "uuid4", new=lambda: "12345678")
 class TestDashboardProvider(unittest.TestCase):
     def setUp(self):
         patcher = patch("charms.grafana_k8s.v0.grafana_dashboard._resolve_dir_against_charm_path")
@@ -130,7 +128,7 @@ class TestDashboardProvider(unittest.TestCase):
         self.assertDictEqual(
             {
                 "templates": RELATION_TEMPLATES_DATA,
-                "uuid": "12345678",
+                "uuid": "10aa88d3d745c3c1",
             },
             data,
         )
@@ -146,7 +144,7 @@ class TestDashboardProvider(unittest.TestCase):
 
         expected_data_builtin_dashboards = {
             "templates": copy.deepcopy(RELATION_TEMPLATES_DATA),
-            "uuid": "12345678",
+            "uuid": "10aa88d3d745c3c1",
         }
 
         expected_data = copy.deepcopy(expected_data_builtin_dashboards)
@@ -163,6 +161,7 @@ class TestDashboardProvider(unittest.TestCase):
                 "unit": "provider-tester/0",
             },
         }
+        expected_data["uuid"] = "61a7f8340b79b2d7"
 
         self.assertDictEqual(expected_data, actual_data)
         self.harness.charm.provider.remove_non_builtin_dashboards()
@@ -182,7 +181,7 @@ class TestDashboardProvider(unittest.TestCase):
 
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "12345678",
+            "uuid": "10aa88d3d745c3c1",
         }
 
         self.assertDictEqual(expected_data, actual_data)
@@ -203,7 +202,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "12345678",
+            "uuid": "10aa88d3d745c3c1",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -214,7 +213,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": MANUAL_TEMPLATE_DATA,
-            "uuid": "12345678",
+            "uuid": "62d5ee2efbab0247",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -226,7 +225,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "12345678",
+            "uuid": "10aa88d3d745c3c1",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -237,7 +236,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": MANUAL_TEMPLATE_DATA_NO_DROPDOWNS,
-            "uuid": "12345678",
+            "uuid": "f8b869f1372f91d6",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -249,7 +248,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "12345678",
+            "uuid": "10aa88d3d745c3c1",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -260,7 +259,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         empty_data = {
             "templates": {},
-            "uuid": "12345678",
+            "uuid": "44136fa355b3678a",
         }
         self.assertDictEqual(empty_data, actual_data)
 
@@ -272,7 +271,7 @@ class TestDashboardProvider(unittest.TestCase):
         )
         expected_data = {
             "templates": RELATION_TEMPLATES_DATA,
-            "uuid": "12345678",
+            "uuid": "10aa88d3d745c3c1",
         }
         self.assertDictEqual(expected_data, actual_data)
 
@@ -283,6 +282,6 @@ class TestDashboardProvider(unittest.TestCase):
         )
         empty_data = {
             "templates": {},
-            "uuid": "12345678",
+            "uuid": "44136fa355b3678a",
         }
         self.assertDictEqual(empty_data, actual_data)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Based on https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/313

## Solution
<!-- A summary of the solution addressing the above issue -->
```
Line 1372 (GrafanaDashboardProvider._upset_dashboards_on_relation) and Line 1870 (GrafanaDashboardAggregator._update_remote_grafana) use uuid.uuid4(), which generates a new ID on every execution and forces an infinite Juju hook loop. Replace str(uuid.uuid4()) with: `hashlib.sha256(json.dumps(new_templates, sort_keys=True).encode()).hexdigest()[:16]`
```
```
Line 1888 (GrafanaDashboardAggregator.remove_dashboards) lacks an equality guard. Extract the templates first, then hash them by replacing str(uuid.uuid4()) with: remaining_templates = type_convert_stored(...) and then hashing via hashlib.sha256(json.dumps(remaining_templates, sort_keys=True).encode()).hexdigest()[:16]
```
```
Line 1736 (GrafanaDashboardConsumer.set_peer_data) calls json.dumps(data) without sorting dict keys, causing arbitrary databag updates depending on Python's internal dictionary ordering. Force key sorting by changing it to: `json.dumps(data, sort_keys=True)`
```
```
Line 2137 (CosTool.validate_alert_rules) triggers a lint error due to a nondeterministic value written to a temporary file. Since this is an intentional, ephemeral file operation, suppress the linter warning by adding a comment on that line: `# databag-order: ignore`
```
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
