### PR TITLE
feat: blocked on invalid dashboards

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -217,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 51
+LIBPATCH = 52
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -1520,6 +1520,38 @@ class GrafanaDashboardConsumer(Object):
             for relation in relations:
                 self._render_dashboards_and_signal_changed(relation)
 
+    def has_invalid_dashboards(self) -> bool:
+        """Check whether any relation reported invalid dashboards.
+
+        Validation errors written to relation app data by this consumer (see
+        :meth:`_render_dashboards_and_signal_changed`) are read back to determine
+        whether the relationship currently carries an invalid dashboard.
+
+        Returns:
+            True if any related dashboard provider reported dashboard validation
+            errors, False otherwise.
+        """
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if event_data.get("errors"):
+                logger.error(
+                    "Invalid dashboards on relation %s: %s",
+                    relation.id,
+                    event_data["errors"],
+                )
+                return True
+
+        return False
+
     def _on_grafana_dashboard_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Update job config when providers depart.
 
@@ -1592,7 +1624,11 @@ class GrafanaDashboardConsumer(Object):
             except json.JSONDecodeError as e:
                 error = str(e.msg)
                 logger.warning("Invalid JSON in Grafana dashboard '{}': {}".format(fname, error))
-                continue
+                relation_has_invalid_dashboards = True
+            except (KeyError, TypeError, AttributeError) as e:
+                error = str(e)
+                logger.warning("Invalid Grafana dashboard '{}': {}".format(fname, error))
+                relation_has_invalid_dashboards = True
 
             # Prepend the relation name and ID to the dashboard ID to avoid clashes with
             # multiple relations with apps from the same charm, or having dashboards with
@@ -1639,6 +1675,12 @@ class GrafanaDashboardConsumer(Object):
 
             # Dropping dashboards for a relation needs to be signalled
             return True
+
+        # Clear any stale validation errors so the charm returns to Active once fixed
+        event_data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+        if event_data.get("errors"):
+            event_data.pop("errors")
+            relation.data[self._charm.app]["event"] = json.dumps(event_data)
 
         stored_data = rendered_dashboards
         currently_stored_data = self._get_stored_dashboards(relation.id)

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -1531,6 +1531,9 @@ class GrafanaDashboardConsumer(Object):
             True if any related dashboard provider reported dashboard validation
             errors, False otherwise.
         """
+        if not self._charm.unit.is_leader():
+            return False
+
         for relation in self._charm.model.relations.get(self._relation_name, []):
             app_data = relation.data.get(self._charm.app)
             if not app_data:

--- a/src/charm.py
+++ b/src/charm.py
@@ -516,6 +516,8 @@ class GrafanaCharm(CharmBase):
         e.add_status(ActiveStatus())
         if status := self._check_wrong_relations():
             e.add_status(status)
+        if self.dashboard_consumer.has_invalid_dashboards():
+            e.add_status(BlockedStatus("Invalid dashboards. See debug-log"))
         e.add_status(self.resource_patch.get_status())
         e.add_status(self._grafana_config.get_status())
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import json
 from unittest.mock import patch
 
+from ops import ActiveStatus, BlockedStatus
 from pytest import mark
 import yaml
 from ops.testing import (Relation,
@@ -282,3 +283,40 @@ def test_primary_sets_correct_peer_data(ctx, base_state, peer_relation):
         charm = mgr.charm
         unit_binding = charm.model.get_binding("grafana")
         assert unit_binding
+
+
+def test_blocked_status_on_invalid_dashboard(ctx: Context, base_state, peer_relation):
+    # GIVEN a grafana-dashboard relation whose local app data contains validation errors
+    # (as written by GrafanaDashboardConsumer._render_dashboards_and_signal_changed)
+    dashboard_rel = Relation(
+        "grafana-dashboard",
+        remote_app_name="some-charm",
+        local_app_data={
+            "event": json.dumps({
+                "errors": [{"dashboard_id": "file:my_dash.json", "error": "KeyError: 'query'"}]
+            })
+        },
+    )
+    state = replace(base_state, relations={peer_relation, dashboard_rel})
+
+    # WHEN any event fires (update-status triggers collect-unit-status)
+    with ctx(ctx.on.update_status(), state) as mgr:
+        mgr.run()
+        # THEN the unit is blocked with a relevant message
+        assert mgr.charm.unit.status == BlockedStatus("Invalid dashboards. See debug-log")
+
+
+def test_active_status_without_invalid_dashboards(ctx: Context, base_state, peer_relation):
+    # GIVEN a grafana-dashboard relation with no validation errors in app data
+    dashboard_rel = Relation(
+        "grafana-dashboard",
+        remote_app_name="some-charm",
+        local_app_data={},
+    )
+    state = replace(base_state, relations={peer_relation, dashboard_rel})
+
+    # WHEN any event fires
+    with ctx(ctx.on.update_status(), state) as mgr:
+        mgr.run()
+        # THEN the unit is active (no invalid dashboards)
+        assert mgr.charm.unit.status == ActiveStatus()

--- a/tests/unit/test_dashboard_consumer.py
+++ b/tests/unit/test_dashboard_consumer.py
@@ -624,6 +624,112 @@ class TestDashboardConsumer(unittest.TestCase):
             )
             self.assertIn("Invalid JSON in Grafana dashboard 'file:tester'", "\n".join(cm.output))  # type: ignore
 
+    def test_consumer_error_on_missing_query_key(self):
+        """A dashboard with a datasource template var missing 'query' must not crash.
+
+        Regression test for https://github.com/canonical/grafana-k8s-operator/issues/582.
+        The KeyError: 'query' in _convert_dashboard_fields used to propagate uncaught and
+        put the charm into ERROR state.
+        """
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        rels = self.setup_charm_relations()
+
+        # A dashboard whose templating list has a datasource entry without a 'query' key.
+        # This is the exact shape that triggered the crash in the issue.
+        bad_dashboard = json.dumps({
+            "templating": {
+                "list": [{"type": "datasource", "name": "DS_PROMETHEUS"}]
+            },
+            "panels": [],
+            "uid": "deadbeef",
+        })
+        bad_data = {
+            "templates": {
+                "file:bad_dash": {
+                    "charm": "grafana-k8s",
+                    "content": bad_dashboard,
+                    "juju_topology": {
+                        "model": MODEL_INFO["name"],
+                        "model_uuid": MODEL_INFO["uuid"],
+                        "application": "provider-tester",
+                        "unit": "provider-tester/0",
+                    },
+                }
+            },
+            "uuid": "12345678",
+        }
+
+        with self.assertLogs(level="WARNING") as cm:
+            # Must not raise — the hook must survive a malformed dashboard.
+            self.harness.update_relation_data(
+                rels[0],
+                "provider",
+                {"dashboards": json.dumps(bad_data)},
+            )
+            self.assertIn("Invalid Grafana dashboard 'file:bad_dash'", "\n".join(cm.output))
+
+        # has_invalid_dashboards() must return True so the charm can set BlockedStatus.
+        self.assertTrue(self.harness.charm.grafana_consumer.has_invalid_dashboards())
+
+        # The event field on the relation must carry the error.
+        rel = self.harness.model.get_relation("grafana-dashboard", rels[0])
+        assert rel is not None
+        event_data = json.loads(rel.data[self.harness.charm.app].get("event", "{}"))
+        self.assertTrue(len(event_data.get("errors", [])) > 0)
+        self.assertEqual(event_data["errors"][0]["dashboard_id"], "file:bad_dash")
+
+    def test_consumer_errors_cleared_when_dashboard_becomes_valid(self):
+        """After fixing an invalid dashboard, has_invalid_dashboards() must return False."""
+        self.assertEqual(self.harness.charm._stored.dashboard_events, 0)
+        rels = self.setup_charm_relations()
+
+        # First, send an invalid dashboard.
+        bad_dashboard = json.dumps({
+            "templating": {
+                "list": [{"type": "datasource", "name": "DS_PROMETHEUS"}]
+            },
+            "panels": [],
+            "uid": "deadbeef",
+        })
+        bad_data = {
+            "templates": {
+                "file:bad_dash": {
+                    "charm": "grafana-k8s",
+                    "content": bad_dashboard,
+                    "juju_topology": {
+                        "model": MODEL_INFO["name"],
+                        "model_uuid": MODEL_INFO["uuid"],
+                        "application": "provider-tester",
+                        "unit": "provider-tester/0",
+                    },
+                }
+            },
+            "uuid": "11111111",
+        }
+        with self.assertLogs(level="WARNING"):
+            self.harness.update_relation_data(
+                rels[0], "provider", {"dashboards": json.dumps(bad_data)}
+            )
+        self.assertTrue(self.harness.charm.grafana_consumer.has_invalid_dashboards())
+
+        # Now fix the dashboard by sending a valid one.
+        good_data = {
+            "templates": {"file:tester": DASHBOARD_DATA},
+            "uuid": "22222222",
+        }
+        self.harness.update_relation_data(
+            rels[0], "provider", {"dashboards": json.dumps(good_data)}
+        )
+
+        # has_invalid_dashboards() must return False once errors are cleared.
+        self.assertFalse(self.harness.charm.grafana_consumer.has_invalid_dashboards())
+
+        # The event field must no longer carry errors.
+        rel = self.harness.model.get_relation("grafana-dashboard", rels[0])
+        assert rel is not None
+        event_data = json.loads(rel.data[self.harness.charm.app].get("event", "{}"))
+        self.assertEqual(event_data.get("errors", []), [])
+
     def test_consumer_templates_datasource(self):
         self.assertEqual(len(self.harness.charm.grafana_consumer._stored.dashboards), 0)
         self.assertEqual(self.harness.charm._stored.dashboard_events, 0)


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #582.
Similar to how we set blocked status when there are invalid Prometheus rules: https://github.com/canonical/prometheus-k8s-operator/pull/817
Or when there are invalid Loki rules: https://github.com/canonical/loki-k8s-operator/pull/622

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Writes validation errors to relation data when there are invalid dashboards for a relation. A dashboard can be considered invalid if:
- Json decode errors
- LZMA compression/uncompression errors
- Key, Attribute, Type errors
2. On a subsequent hook, if the invalid dashboards are fixed, the errors written to relation data are cleared.
3. The dashboard lib now provides a public helper which iterates over local app data and returns true if any validation errors are written to the databag.
4. On the subsequent `collect_unit_status`, the public dashboard helper from (3) is called and if the return is true, the charm is set to blocked.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Before
Deploy this bundle:
```yaml
bundle: kubernetes
applications:
  cos-config:
    charm: cos-configuration-k8s
    channel: dev/edge
    revision: 123
    base: ubuntu@26.04/stable
    resources:
      git-sync-image: 38
    scale: 1
    options:
      git_branch: main
      git_repo: https://github.com/sinapah/cos-config
      grafana_dashboards_path: valid_dashboards
    constraints: arch=amd64
    storage:
      content-from-git: kubernetes,1,1024M
    trust: true
  graf:
    charm: grafana-k8s
    channel: dev/edge
    revision: 198
    base: ubuntu@26.04/stable
    resources:
      grafana-image: 79
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 397
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 173
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - cos-config:grafana-dashboards
  - graf:grafana-dashboard
- - graf:ingress
  - traefik:ingress

```
Initially, COS Config is pulling only valid dashboards from a repo.

Now, do `juju config cos-config grafana_dashboards_path=invalid_dashboards`.

Now, Grafana will error out with the same error you see in #582.

### After
Now, refresh Grafana so it has the changes in this PR.

If you set COS Config to pull the invalid dashboards again.

Now, Grafana should write the validation errors to relation data with COS Config. See `jc cos-config/0`:
```yaml
cos-config/0:
  opened-ports: []
  charm: ch:amd64/cos-configuration-k8s-123
  leader: true
  life: alive
  relation-info:
  - relation-id: 3
    endpoint: grafana-dashboards
    related-endpoint: grafana-dashboard
    application-data:
      event: '{"errors": [{"dashboard_id": "file:missing-keys", "error": "''query''"}]}'
    related-units:
      graf/0:

```
Grafana is now blocked.

Now if you reset COS Config to pull the valid dashboards, Grafana will clear the validation errors from relation data and Grafana will become active again:
```
cos-config/0:
  opened-ports: []
  charm: ch:amd64/cos-configuration-k8s-123
  leader: true
  life: alive
  relation-info:
  - relation-id: 3
    endpoint: grafana-dashboards
    related-endpoint: grafana-dashboard
    application-data:
      event: '{}'
    related-units:
      graf/0:

```
## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
